### PR TITLE
MODSIDECAR-5 Fix native image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ mvn package -Pnative
 Or, if you don't have GraalVM installed, you can run the native executable build in a container using:
 
 ```shell script
-mvn package -Pnative -Dquarkus.native.container-build=true
+mvn install -Pnative -DskipTests \
+  -Dquarkus.native.container-build=true \
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
 ```
 
 You can then execute your native executable with: `./target/folio-module-sidecar-0.0.1-SNAPSHOT.jar`
@@ -106,13 +108,15 @@ This [Dockerfile](docker/Dockerfile.native) is used in order to build a containe
 native (no JVM) mode. Before building the container image run:
 
 ```shell
-./mvnw package -Pnative
+mvn install -Pnative -DskipTests \
+  -Dquarkus.native.container-build=true \
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17
 ```
 
 Then, build the image with:
 
 ```shell
-docker build -f docker/Dockerfile.native -t quarkus/sidecar .
+docker build -f docker/Dockerfile.native-micro -t folio-module-sidecar-native .
 ```
 
 Then run the container using:
@@ -146,7 +150,7 @@ and micro docker image size 94.65 Mb
 To build a native executable of your Quarkus application using GraalVM, use the following command:
 
 ```
-mvn package -Pnative
+mvn install -DskipTests -Pnative
 ```
 
 If you use this command, you must have GraalVM and the necessary build tools installed on your machine.
@@ -154,14 +158,7 @@ Including, Visual Studio C++ build tools, If you use windows. Then, _x64 Native 
 be opened to run previous command to build a native binary.
 Otherwise, you may encounter errors during the build process.
 The resulting native binaries size is 64964kb, its docker image's size is 102.56 MB,
-and micro docker image size 95.91 MB,
-aslo this appraoch _has some drawbacks executing in a docker container._
-
-Both approaches requires to add
-`--initialize-at-run-time=io.smallrye.faulttolerance.standalone.StandaloneFaultToleranceSpi\$LazyDependenciesHolder`
-argument in either `application.properties` file or `pom.xml` or as `command-line argument`,
-because this library is being initialized during image built-up time, which leads to failed generation of a native
-binary.
+and micro docker image size 95.91 MB,  this approach _has some drawbacks executing in a docker container._
 
 In general, if you are developing on a machine that has _GraalVM and the necessary build tools installed,
 it is faster to use GraalVM approach_.
@@ -214,6 +211,8 @@ for more details please visit https://quarkus.io/guides/building-native-image
 | MOD_USERS_CACHE_EXPIRATION_SECONDS           | 300                                 |  false   | Users cache ttl.                                                                                                                                              |
 | MOD_USERS_CACHE_INITIAL_CAPACITY             | 50                                  |  false   | Initial users cache size.                                                                                                                                     |
 | MOD_USERS_CACHE_MAX_CAPACITY                 | 1000                                |  false   | Max user cache size.                                                                                                                                          |
+| SC_LOG_LEVEL                                 | INFO                                |  false   | Log level for sidecar package: `org.folio.sidecar`.                                                                                                           |
+| ROOT_LOG_LEVEL                               | INFO                                |  false   | Root log level.                                                                                                                                               |
 
 ### Secure storage environment variables
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -3,18 +3,19 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package -Pnative
+# ./mvnw package -Dnative
 #
 # Then, build the image with:
 #
-# docker build -f docker/Dockerfile.native -t quarkus/sidecar .
+# docker build -f src/main/docker/Dockerfile.native -t folio-module-sidecar-native .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/sidecar
+# docker run -i --rm -p 8080:8080 quarkus/getting-started
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
@@ -24,4 +25,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8081
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -11,7 +11,7 @@
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started
+# docker run -i --rm -p 8081:8081 folio-module-sidecar-native
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9

--- a/docker/Dockerfile.native-micro
+++ b/docker/Dockerfile.native-micro
@@ -6,24 +6,25 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package -Pnative
+# ./mvnw package -Dnative
 #
 # Then, build the image with:
 #
-# docker build -f docker/Dockerfile.native-micro -t quarkus/sidecar .
+# docker build -f docker/Dockerfile.native-micro -t folio-module-sidecar-native .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/sidecar
+# docker run -i --rm -p 8081:8081 quarkus/getting-started
 #
 ###
-FROM quay.io/quarkus/quarkus-micro-image:1.0
-
+FROM quay.io/quarkus/quarkus-micro-image:2.0
 WORKDIR /work/
-RUN chown 1001 /work && chmod "g+rwX" /work && chown 1001:root /work
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
 COPY --chown=1001:root target/*-runner /work/application
 
 EXPOSE 8081
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/Dockerfile.native-micro
+++ b/docker/Dockerfile.native-micro
@@ -14,7 +14,7 @@
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8081:8081 quarkus/getting-started
+# docker run -i --rm -p 8081:8081 folio-module-sidecar-native
 #
 ###
 FROM quay.io/quarkus/quarkus-micro-image:2.0

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <quarkus.package.add-runner-suffix>false</quarkus.package.add-runner-suffix>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.6.1</quarkus.platform.version>
+    <quarkus.platform.version>3.6.4</quarkus.platform.version>
     <applications-poc-tools.version>1.0.0-SNAPSHOT</applications-poc-tools.version>
 
     <lombok.version>1.18.30</lombok.version>
@@ -370,7 +370,10 @@
         <skipITs>false</skipITs>
         <quarkus.package.type>native</quarkus.package.type>
         <quarkus.native.additional-build-args>
-          --initialize-at-run-time=io.smallrye.faulttolerance.standalone.StandaloneFaultToleranceSpi\$LazyDependenciesHolder
+          -march=native,\
+          --initialize-at-run-time=org.apache.http.impl.auth.NTLMEngineImpl,\
+          --initialize-at-run-time=com.bettercloud.vault.rest.Rest,\
+          -H:ReflectionConfigurationFiles=reflection-config.json
         </quarkus.native.additional-build-args>
       </properties>
     </profile>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 # quarkus configuration
+quarkus.log.level=${ROOT_LOG_LEVEL:INFO}
+quarkus.log.category."org.folio.sidecar".level=${SC_LOG_LEVEL:DEBUG}
 quarkus.application.name=folio-module-sidecar
 quarkus.http.port=8081
 quarkus.jackson.fail-on-unknown-properties=false

--- a/src/main/resources/reflection-config.json
+++ b/src/main/resources/reflection-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name" : "com.github.benmanes.caffeine.cache.SSLMSA",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  }
+]


### PR DESCRIPTION
## Purpose

The last time we tried to build sidecars to native binaries it failed.  We might need to update some dependencies, or even Quarkus itself.

- Remove SecureStore lib
- Replace SecureStore lib with native Quarkus implementation
- Build sidecar native image and check it
- Check image on evrk env if possible

## Approach

- SecureStore library is working in native image build with adding native build argument: `--initialize-at-run-time=com.bettercloud.vault.rest.Rest` and `--initialize-at-run-time=org.apache.http.impl.auth.NTLMEngineImpl`
- Fix issue for caffeine cache during native build
- Raise base version of quarkus `v3.6.1` -> `v3.6.4`
- Add environment variables to control log level for root and `org.folio.sidecar` package

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
