### PR TITLE
FIX: rollback quarkus platform version to 3.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <quarkus.package.add-runner-suffix>false</quarkus.package.add-runner-suffix>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.7.1</quarkus.platform.version>
+    <quarkus.platform.version>3.6.8</quarkus.platform.version>
     <applications-poc-tools.version>1.0.0</applications-poc-tools.version>
 
     <lombok.version>1.18.30</lombok.version>


### PR DESCRIPTION
## Purpose

Rollback dependabot version change

## Approach

- quarkus.platform.version `3.7.1 -> 3.6.8`

