### PR TITLE
MODCONSKC-4: fix impersonation users while self request is happening

### DIFF
--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
@@ -23,7 +23,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.sidecar.integration.keycloak.JsonWebTokenParser;
 import org.folio.sidecar.integration.keycloak.KeycloakImpersonationService;
 import org.folio.sidecar.integration.users.UserService;
-import org.folio.sidecar.service.SidecarSignatureService;
 import org.folio.sidecar.service.filter.IngressRequestFilter;
 
 @Log4j2
@@ -34,7 +33,6 @@ public class KeycloakImpersonationFilter implements IngressRequestFilter {
   private final UserService userService;
   private final JsonWebTokenParser jwtParser;
   private final KeycloakImpersonationService impersonationService;
-  private final SidecarSignatureService sidecarSignatureService;
 
   @Override
   public Future<RoutingContext> filter(RoutingContext routingContext) {

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
@@ -22,6 +22,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.sidecar.integration.keycloak.JsonWebTokenParser;
 import org.folio.sidecar.integration.keycloak.KeycloakImpersonationService;
 import org.folio.sidecar.integration.users.UserService;
+import org.folio.sidecar.service.SidecarSignatureService;
 import org.folio.sidecar.service.filter.IngressRequestFilter;
 
 @Log4j2
@@ -32,6 +33,7 @@ public class KeycloakImpersonationFilter implements IngressRequestFilter {
   private final UserService userService;
   private final JsonWebTokenParser jwtParser;
   private final KeycloakImpersonationService impersonationService;
+  private final SidecarSignatureService sidecarSignatureService;
 
   @Override
   public Future<RoutingContext> filter(RoutingContext routingContext) {
@@ -53,6 +55,9 @@ public class KeycloakImpersonationFilter implements IngressRequestFilter {
 
   @Override
   public boolean shouldSkip(RoutingContext routingContext) {
+    if (sidecarSignatureService.isSelfRequest(routingContext)) {
+      return true;
+    }
     var tenant = getTenant(routingContext);
     var parsedToken = getParsedToken(routingContext);
     if (parsedToken.isEmpty() || isBlank(tenant)) {

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakImpersonationFilter.java
@@ -8,6 +8,7 @@ import static org.folio.sidecar.utils.JwtUtils.extractTokenIssuer;
 import static org.folio.sidecar.utils.JwtUtils.getUserIdClaim;
 import static org.folio.sidecar.utils.RoutingUtils.getParsedToken;
 import static org.folio.sidecar.utils.RoutingUtils.getTenant;
+import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 import static org.folio.sidecar.utils.RoutingUtils.putParsedToken;
 
 import io.quarkus.security.ForbiddenException;
@@ -55,7 +56,7 @@ public class KeycloakImpersonationFilter implements IngressRequestFilter {
 
   @Override
   public boolean shouldSkip(RoutingContext routingContext) {
-    if (sidecarSignatureService.isSelfRequest(routingContext)) {
+    if (isSelfRequest(routingContext)) {
       return true;
     }
     var tenant = getTenant(routingContext);


### PR DESCRIPTION
## Purpose

Fix the issue [MODCONSKC-4](https://folio-org.atlassian.net/browse/MODCONSKC-4)

## Approach

- add condition if self request in ImpesonationService

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [x] Code coverage on new code is 80% or greater
    - [x] Duplications on new code is 3% or less
    - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
