### PR TITLE
MODSIDECAR-25: set user ID by user JWT

### DIFF
--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakSystemJwtFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakSystemJwtFilter.java
@@ -26,6 +26,12 @@ public class KeycloakSystemJwtFilter implements IngressRequestFilter {
 
   private final JsonWebTokenParser tokenParser;
 
+  /**
+   * Finds system token as X-System-Token header and parses it to {@link JsonWebToken} object.
+   *
+   * @param rc - {@link RoutingContext} object to filter
+   * @return {@link Future} of {@link RoutingContext} object
+   */
   @Override
   public Future<RoutingContext> filter(RoutingContext rc) {
     return getSystemToken(rc)

--- a/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
@@ -304,10 +304,10 @@ class KeycloakJwtFilterTest {
   }
 
   @Test
-  void shouldSkip_positive_noRequiredPermissions() {
+  void shouldSkip_negative_noRequiredPermissions() {
     var routingContext = routingContext(scRoutingEntry("not-system"), rc -> {});
     var actual = keycloakJwtFilter.shouldSkip(routingContext);
-    assertThat(actual).isTrue();
+    assertThat(actual).isFalse();
   }
 
   private static RoutingContext routingContext(ScRoutingEntry routingEntry, Consumer<RoutingContext> rcModifier) {

--- a/src/test/java/org/folio/sidecar/it/SidecarIT.java
+++ b/src/test/java/org/folio/sidecar/it/SidecarIT.java
@@ -9,6 +9,8 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_REQUEST_TIMEOUT;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.folio.sidecar.support.TestConstants.USER_ID;
+import static org.folio.sidecar.support.TestUtils.asJson;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -475,5 +477,37 @@ class SidecarIT {
         "errors[0].code", is("read_timeout_error"),
         "errors[0].message", is("Request Timeout")
       );
+  }
+
+  @Test
+  void handleIngressRequest_positive_userJwtTokenShouldBeParsedWhilePermissionsNotRequired() {
+    var authToken = TestJwtGenerator.generateJwtString(keycloakUrl, TestConstants.TENANT_NAME, USER_ID);
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.TOKEN, authToken)
+      .get("/foo/bar")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .contentType(is(APPLICATION_JSON));
+  }
+
+  @Test
+  void handleIngressRequest_negative_401WithWrongJwtWhilePermissionsNotRequired() {
+    var authToken = TestJwtGenerator.generateExpiredJwtToken(keycloakUrl, TestConstants.TENANT_NAME);
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.TOKEN, authToken)
+      .get("/foo/bar")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_UNAUTHORIZED))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .contentType(is(APPLICATION_JSON))
+      .body(is(asJson("json/unauthorized-error.json")));
   }
 }

--- a/src/test/java/org/folio/sidecar/support/TestConstants.java
+++ b/src/test/java/org/folio/sidecar/support/TestConstants.java
@@ -19,6 +19,7 @@ public class TestConstants {
   public static final String TENANT_NAME = "testtenant";
   public static final String FOLIO_ENV = "folio";
   public static final String TENANT_ID = "90b113f0-4e98-45f7-bccc-cf318e13a9bc";
+  public static final String USER_ID = "00000000-0000-0000-0000-111111111111";
   public static final UUID TENANT_UUID = UUID.fromString(TENANT_ID);
   public static final String MODULE_NAME = "mod-foo";
   public static final String SIDECAR_NAME = "sc-mod-foo";

--- a/src/test/java/org/folio/sidecar/support/TestUtils.java
+++ b/src/test/java/org/folio/sidecar/support/TestUtils.java
@@ -56,6 +56,10 @@ public class TestUtils {
     return OBJECT_MAPPER.readTree(json).toString();
   }
 
+  public static String asJson(String path) {
+    return minify(readString(path));
+  }
+
   public static RequestSpecification givenJson() {
     return given()
       .log().ifValidationFails(LogDetail.BODY)

--- a/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
+++ b/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
@@ -50,6 +50,11 @@
                 "methods": [ "POST" ],
                 "pathPattern": "/foo/xyz",
                 "permissionsRequired": [ "foo.xyz.collection.post" ]
+              },
+              {
+                "methods": [ "GET" ],
+                "pathPattern": "/foo/bar",
+                "permissionsRequired": []
               }
             ]
           },

--- a/src/test/resources/mappings/mod-foo-0.2.1.json
+++ b/src/test/resources/mappings/mod-foo-0.2.1.json
@@ -136,6 +136,33 @@
           "Content-Type": "application/json"
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/foo/bar",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json"
+          },
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          },
+          "X-Okapi-Request-Id": {
+            "matches": "\\d{6}/foo"
+          },
+          "X-Okapi-User-Id": {
+            "equalTo": "00000000-0000-0000-0000-111111111111"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Okapi-Tenant": "testtenant"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODSIDECAR-25
Sidecar should parse, extract from jwt, and put into header user_id.

## Approach

- allow KeycloakJwtFilter to parse user token while  permissions are not required

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

