### PR TITLE
MODSIDECAR-27 Unable to load reference/sample data

### DIFF
--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java
@@ -10,6 +10,7 @@ import static org.folio.sidecar.utils.JwtUtils.getUserIdClaim;
 import static org.folio.sidecar.utils.RoutingUtils.getParsedSystemToken;
 import static org.folio.sidecar.utils.RoutingUtils.hasNoPermissionsRequired;
 import static org.folio.sidecar.utils.RoutingUtils.hasUserIdHeader;
+import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isSystemRequest;
 import static org.folio.sidecar.utils.RoutingUtils.putParsedToken;
 import static org.folio.sidecar.utils.RoutingUtils.setUserIdHeader;
@@ -56,7 +57,7 @@ public class KeycloakJwtFilter implements IngressRequestFilter {
 
   @Override
   public boolean shouldSkip(RoutingContext rc) {
-    return isSystemRequest(rc);
+    return isSystemRequest(rc) || isSelfRequest(rc);
   }
 
   @Override

--- a/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
@@ -11,6 +11,7 @@ import static org.folio.sidecar.support.TestConstants.AUTH_TOKEN;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.MODULE_URL;
 import static org.folio.sidecar.utils.RoutingUtils.SC_ROUTING_ENTRY_KEY;
+import static org.folio.sidecar.utils.RoutingUtils.SELF_REQUEST_KEY;
 import static org.folio.sidecar.utils.SecurityUtils.JWT_OKAPI_USER_ID_CLAIM;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -140,6 +141,7 @@ class KeycloakJwtFilterTest {
       when(rc.request()).thenReturn(request);
       when(rc.get(SYSTEM_TOKEN)).thenReturn(systemJwt);
       when(request.headers()).thenReturn(requestHeaders);
+      when(rc.get(SELF_REQUEST_KEY)).thenReturn(false);
     });
 
     var jsonWebToken = mock(JsonWebToken.class);
@@ -168,6 +170,7 @@ class KeycloakJwtFilterTest {
       when(rc.request()).thenReturn(request);
       when(rc.get(SYSTEM_TOKEN)).thenReturn(systemJwt);
       when(request.headers()).thenReturn(requestHeaders);
+      when(rc.get(SELF_REQUEST_KEY)).thenReturn(false);
     });
 
     when(jsonWebTokenParser.parse(dummyToken)).thenThrow(new ParseException(INVALID_SEGMENTS_JWT_ERROR_MSG));
@@ -193,6 +196,7 @@ class KeycloakJwtFilterTest {
       when(rc.request()).thenReturn(request);
       when(rc.get(SYSTEM_TOKEN)).thenReturn(systemJwt);
       when(request.headers()).thenReturn(requestHeaders);
+      when(rc.get(SELF_REQUEST_KEY)).thenReturn(false);
     });
 
     var result = keycloakJwtFilter.applyFilter(routingContext);
@@ -214,6 +218,7 @@ class KeycloakJwtFilterTest {
       when(rc.request()).thenReturn(request);
       when(rc.get(SYSTEM_TOKEN)).thenReturn(systemJwt);
       when(request.headers()).thenReturn(requestHeaders);
+      when(rc.get(SELF_REQUEST_KEY)).thenReturn(false);
     });
 
     when(jsonWebTokenParser.parse(AUTH_TOKEN)).thenThrow(new ParseException("Invalid JWT"));
@@ -299,6 +304,15 @@ class KeycloakJwtFilterTest {
   @Test
   void shouldSkip_positive_systemRequest() {
     var routingContext = routingContext(scRoutingEntry("system", "foo.item.get"), rc -> {});
+    var actual = keycloakJwtFilter.shouldSkip(routingContext);
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void shouldSkip_positive_selfRequest() {
+    var routingContext = routingContext(scRoutingEntry("not-system", "foo.item.get"),
+      rc -> when(rc.get(SELF_REQUEST_KEY)).thenReturn(true));
+
     var actual = keycloakJwtFilter.shouldSkip(routingContext);
     assertThat(actual).isTrue();
   }

--- a/src/test/java/org/folio/sidecar/it/SidecarIT.java
+++ b/src/test/java/org/folio/sidecar/it/SidecarIT.java
@@ -88,6 +88,29 @@ class SidecarIT {
   }
 
   @Test
+  void handleIngressRequest_positive_selfRequestWithoutToken() {
+    var signature = TestUtils.getSignature();
+
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, signature)
+      .get("/foo/entities")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .contentType(is(APPLICATION_JSON))
+      .body(
+        "totalRecords", is(1),
+        "entities[0].id", is("d12c8c0c-d387-4bd5-9ad6-c02b41abe4ec"),
+        "entities[0].name", is("Test entity"),
+        "entities[0].description", is("A Test entity description")
+      );
+  }
+
+  @Test
   void handleIngressRequest_positive_entityById() {
     TestUtils.givenJson()
       .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)


### PR DESCRIPTION
## Purpose

In a recent deployment, it was observed that for some modules, we were unable to load reference and/or sample data.  This needs to be investigated and resolved.

One module which had such problems was mod-feesfines.  Unfortunately details are sparse, but it sounds like this may be related to authorization of requests made by a module (e.g. feesfines) to its own APIs. 
US: [MODSIDECAR-27](https://folio-org.atlassian.net/browse/MODSIDECAR-27)

## Approach

* skip `KeycloakJwtFilter` in case of self request

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
