### PR TITLE
MODSIDECAR-27 Skip tenant filter in case of self request

### DIFF
--- a/src/main/java/org/folio/sidecar/service/filter/SidecarSignatureFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/SidecarSignatureFilter.java
@@ -20,6 +20,6 @@ public class SidecarSignatureFilter implements IngressRequestFilter {
 
   @Override
   public int getOrder() {
-    return 160;
+    return 170;
   }
 }

--- a/src/main/java/org/folio/sidecar/service/filter/TenantFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/TenantFilter.java
@@ -2,6 +2,7 @@ package org.folio.sidecar.service.filter;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 
 import io.vertx.core.Future;
 import io.vertx.ext.web.RoutingContext;
@@ -29,8 +30,8 @@ public class TenantFilter implements IngressRequestFilter {
   }
 
   @Override
-  public boolean shouldSkip(RoutingContext routingContext) {
-    return RoutingUtils.isTenantInstallRequest(routingContext);
+  public boolean shouldSkip(RoutingContext rc) {
+    return RoutingUtils.isTenantInstallRequest(rc) || isSelfRequest(rc);
   }
 
   @Override


### PR DESCRIPTION
## Purpose
Ignore tenant filter in case of self request. The case is relevant when module calls its own API during tenant enabling.

## Approach
* add a condition to ignore tenant filter is case of self request

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
