### PR TITLE
MODSIDECAR-38: set x-okapi-permissions if permissionsDesired exists

### DIFF
--- a/src/main/java/org/folio/sidecar/integration/am/model/ModuleBootstrapEndpoint.java
+++ b/src/main/java/org/folio/sidecar/integration/am/model/ModuleBootstrapEndpoint.java
@@ -14,6 +14,7 @@ public class ModuleBootstrapEndpoint {
   private String pathPattern;
   private String path;
   private List<String> permissionsRequired;
+  private List<String> permissionsDesired;
 
   /**
    * Constructor.

--- a/src/main/java/org/folio/sidecar/integration/users/UserService.java
+++ b/src/main/java/org/folio/sidecar/integration/users/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
 
     return serviceTokenProvider.getServiceToken(rc)
       .flatMap(serviceToken -> findPermissionsByQuery(userId, tenant, queryParams, serviceToken))
-      .onFailure(error -> log.error("Failed to find user permissions: user = {}, tenant = {}", userId, tenant, error));
+      .onFailure(error -> log.warn("Failed to find user permissions: user = {}, tenant = {}", userId, tenant, error));
   }
 
   private Future<List<String>> findPermissionsByQuery(String userId, String tenant,

--- a/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
@@ -1,0 +1,67 @@
+package org.folio.sidecar.service.filter;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.join;
+import static org.folio.sidecar.integration.okapi.OkapiHeaders.PERMISSIONS;
+import static org.folio.sidecar.utils.CollectionUtils.isEmpty;
+import static org.folio.sidecar.utils.RoutingUtils.getPermissionsDesired;
+import static org.folio.sidecar.utils.RoutingUtils.getTenant;
+import static org.folio.sidecar.utils.RoutingUtils.getUserIdHeader;
+import static org.folio.sidecar.utils.RoutingUtils.hasPermissionsDesired;
+
+import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.sidecar.integration.users.UserService;
+
+@Log4j2
+@ApplicationScoped
+@RequiredArgsConstructor
+public class DesiredPermissionsFilter implements IngressRequestFilter {
+
+  private final UserService userService;
+
+  @Override
+  public int getOrder() {
+    return 171;
+  }
+
+  @Override
+  public Future<RoutingContext> filter(RoutingContext rc) {
+    rc.request().headers().remove(PERMISSIONS);
+    var userIdHeader = getUserIdHeader(rc);
+
+    if (userIdHeader.isEmpty()) {
+      log.warn("Skipping population of X-Okapi-Permissions: user ID not found.");
+      return succeededFuture(rc);
+    }
+
+    if (hasPermissionsDesired(rc)) {
+      return succeededFuture(userIdHeader.get())
+        .flatMap(userId -> userService.findUserPermissions(rc, getPermissionsDesired(rc), userId, getTenant(rc)))
+        .flatMap(permissions -> succeededFuture(populatePermissions(rc, permissions)))
+        .otherwise(error -> {
+          log.warn("Error occurred while searching user permissions: user = {}, tenant = {}", userIdHeader.get(),
+            getTenant(rc), error);
+          return rc;
+        });
+    }
+
+    return succeededFuture(rc);
+  }
+
+  private static RoutingContext populatePermissions(RoutingContext rc, List<String> permissions) {
+    if (isEmpty(permissions)) {
+      log.warn("Skipping population of X-Okapi-Permissions: permissions is empty.");
+      return rc;
+    }
+
+    var perms = join(",", permissions);
+    rc.request().headers().set(PERMISSIONS, perms);
+    log.info("X-Okapi-Permissions populated, permissions = {}", perms);
+    return rc;
+  }
+}

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -6,8 +6,10 @@ import static org.folio.sidecar.integration.okapi.OkapiHeaders.TENANT;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.TOKEN;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.USER_ID;
 import static org.folio.sidecar.utils.CollectionUtils.isEmpty;
+import static org.folio.sidecar.utils.CollectionUtils.isNotEmpty;
 
 import io.vertx.ext.web.RoutingContext;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.AccessLevel;
@@ -171,5 +173,19 @@ public class RoutingUtils {
 
   public static void setUserIdHeader(RoutingContext rc, String userId) {
     rc.request().headers().set(USER_ID, userId);
+  }
+
+  public static Optional<String> getUserIdHeader(RoutingContext rc) {
+    return Optional.ofNullable(rc.request().headers().get(USER_ID));
+  }
+
+  public static boolean hasPermissionsDesired(RoutingContext rc) {
+    return isNotEmpty(getPermissionsDesired(rc));
+  }
+
+  public static List<String> getPermissionsDesired(RoutingContext rc) {
+    var scRoutingEntry = getScRoutingEntry(rc);
+    var endpoint = scRoutingEntry.getRoutingEntry();
+    return endpoint.getPermissionsDesired();
   }
 }

--- a/src/test/java/org/folio/sidecar/it/SidecarIT.java
+++ b/src/test/java/org/folio/sidecar/it/SidecarIT.java
@@ -620,4 +620,34 @@ class SidecarIT {
         "errors[0].message", is("Unauthorized")
       );
   }
+
+  @Test
+  void handleIngressRequest_positive_permissionHeaderPopulated() {
+    var authToken = TestJwtGenerator.generateJwtString(keycloakUrl, TestConstants.TENANT_NAME, USER_ID);
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.TOKEN, authToken)
+      .get("/bar/foo")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .contentType(is(APPLICATION_JSON));
+  }
+
+  @Test
+  void handleIngressRequest_positive_permissionHeaderRemoved() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.PERMISSIONS, "foo.bar.item.get")
+      .get("/foo/bar")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .contentType(is(APPLICATION_JSON));
+  }
 }

--- a/src/test/java/org/folio/sidecar/service/filter/DesiredPermissionsFilterTest.java
+++ b/src/test/java/org/folio/sidecar/service/filter/DesiredPermissionsFilterTest.java
@@ -1,0 +1,94 @@
+package org.folio.sidecar.service.filter;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.MultiMap.caseInsensitiveMultiMap;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
+import static org.folio.sidecar.support.TestConstants.USER_ID;
+import static org.folio.sidecar.support.TestValues.routingContext;
+import static org.folio.sidecar.utils.RoutingUtils.getScRoutingEntry;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.http.HttpServerRequest;
+import java.util.List;
+import org.folio.sidecar.integration.okapi.OkapiHeaders;
+import org.folio.sidecar.integration.users.UserService;
+import org.folio.support.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class DesiredPermissionsFilterTest {
+
+  @InjectMocks private DesiredPermissionsFilter filter;
+
+  @Mock private UserService userService;
+  @Mock private HttpServerRequest request;
+
+  @AfterEach
+  void tearDown() {
+    verifyNoMoreInteractions(userService);
+  }
+
+  @Test
+  void filter_positive_findingFailed() {
+    var rc = routingContext(TENANT_NAME);
+    rc.request().headers().add(OkapiHeaders.USER_ID, USER_ID);
+    var permissionsDesired = List.of("perm1", "perm2");
+    var headers = caseInsensitiveMultiMap()
+      .add(OkapiHeaders.USER_ID, USER_ID)
+      .add(OkapiHeaders.TENANT, TENANT_NAME);
+    getScRoutingEntry(rc).getRoutingEntry().setPermissionsDesired(permissionsDesired);
+
+    when(userService.findUserPermissions(rc, permissionsDesired, USER_ID, TENANT_NAME))
+      .thenReturn(failedFuture("Error"));
+    when(rc.request()).thenReturn(request);
+    when(request.getHeader(OkapiHeaders.TENANT)).thenReturn(TENANT_NAME);
+    when(request.headers()).thenReturn(headers);
+
+    var resultFuture = filter.filter(rc);
+
+    assertThat(resultFuture.succeeded()).isTrue();
+    verify(userService).findUserPermissions(rc, permissionsDesired, USER_ID, TENANT_NAME);
+  }
+
+  @Test
+  void filter_positive_userIdNotFound() {
+    var rc = routingContext(TENANT_NAME);
+    var resultFuture = filter.filter(rc);
+
+    assertThat(resultFuture.succeeded()).isTrue();
+    verifyNoInteractions(userService);
+  }
+
+  @Test
+  void filter_positive_permissionsDesiredNotFound() {
+    var rc = routingContext(TENANT_NAME);
+    rc.request().headers().add(OkapiHeaders.USER_ID, USER_ID);
+    var resultFuture = filter.filter(rc);
+
+    assertThat(resultFuture.succeeded()).isTrue();
+    verifyNoInteractions(userService);
+  }
+
+  @Test
+  void filter_positive_permissionsHeaderRemoved() {
+    var rc = routingContext(TENANT_NAME);
+    rc.request().headers().add(OkapiHeaders.USER_ID, USER_ID);
+    rc.request().headers().add(OkapiHeaders.PERMISSIONS, "perm1,perm2");
+
+    var resultFuture = filter.filter(rc);
+
+    assertThat(resultFuture.succeeded()).isTrue();
+    assertThat(rc.request().headers().contains(OkapiHeaders.PERMISSIONS)).isFalse();
+    verifyNoInteractions(userService);
+  }
+}

--- a/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
+++ b/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
@@ -55,6 +55,11 @@
                 "methods": [ "GET" ],
                 "pathPattern": "/foo/bar",
                 "permissionsRequired": []
+              },
+              {
+                "methods": [ "GET" ],
+                "pathPattern": "/bar/foo",
+                "permissionsDesired": ["bar.foo.desired.*", "bar.foo.item.get"]
               }
             ]
           },

--- a/src/test/resources/mappings/mod-foo-0.2.1.json
+++ b/src/test/resources/mappings/mod-foo-0.2.1.json
@@ -177,6 +177,35 @@
           },
           "X-Okapi-Request-Id": {
             "matches": "\\d{6}/foo"
+          },
+          "X-Okapi-Permissions": {
+            "absent": true
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Okapi-Tenant": "testtenant"
+        }
+      }
+    }, {
+      "request": {
+        "method": "GET",
+        "urlPath": "/bar/foo",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json"
+          },
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          },
+          "X-Okapi-Request-Id": {
+            "matches": "\\d{6}/bar"
+          },
+          "X-Okapi-Permissions": {
+            "equalTo": "bar.foo.desired.get,bar.foo.desired.post,bar.foo.item.get"
           }
         }
       },

--- a/src/test/resources/mappings/users/get-user-by-id.json
+++ b/src/test/resources/mappings/users/get-user-by-id.json
@@ -39,6 +39,31 @@
           "X-Okapi-Tenant": "testtenant"
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "/users/00000000-0000-0000-0000-111111111111/permissions?desiredPermissions=bar.foo.desired.*&desiredPermissions=bar.foo.item.get",
+        "headers": {
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Okapi-Tenant": "testtenant"
+        },
+        "jsonBody": {
+          "permissions": [
+            "bar.foo.desired.get",
+            "bar.foo.desired.post",
+            "bar.foo.item.get"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODSIDECAR-38
When handling ingress requests destined for endpoints specifying desiredPermissions, the sidecar should check if the user in the current request context has those desiredPermissions, and if they do, provide the X-Okapi-Permissions header on the proxy request to the module, with the appropriate permissions as the value.

## Approach

- add a filter that populates `x-okapi-permissions`
- add tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.
