### PR TITLE
MODSIDECAR-38: change x-okapi-permission format

### DIFF
--- a/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
@@ -40,11 +40,12 @@ public class DesiredPermissionsFilter implements IngressRequestFilter {
     }
 
     if (hasPermissionsDesired(rc)) {
-      return succeededFuture(userIdHeader.get())
-        .flatMap(userId -> userService.findUserPermissions(rc, getPermissionsDesired(rc), userId, getTenant(rc)))
-        .flatMap(permissions -> succeededFuture(populatePermissions(rc, permissions)))
+      var userId = userIdHeader.get();
+      return succeededFuture(userId)
+        .flatMap(id -> userService.findUserPermissions(rc, getPermissionsDesired(rc), userId, getTenant(rc)))
+        .flatMap(permissions -> succeededFuture(populatePermissions(rc, permissions, userId)))
         .otherwise(error -> {
-          log.warn("Error occurred while searching user permissions: user = {}, tenant = {}", userIdHeader.get(),
+          log.warn("Error occurred while searching user permissions: userId = {}, tenant = {}", userId,
             getTenant(rc), error);
           return rc;
         });
@@ -53,15 +54,15 @@ public class DesiredPermissionsFilter implements IngressRequestFilter {
     return succeededFuture(rc);
   }
 
-  private static RoutingContext populatePermissions(RoutingContext rc, List<String> permissions) {
+  private static RoutingContext populatePermissions(RoutingContext rc, List<String> permissions, String userId) {
     if (isEmpty(permissions)) {
-      log.warn("Skipping population of X-Okapi-Permissions: permissions is empty");
+      log.warn("Skipping population of X-Okapi-Permissions: permissions is empty, userId = {}", userId);
       return rc;
     }
 
     var perms = new JsonArray(permissions).encode();
     rc.request().headers().set(PERMISSIONS, perms);
-    log.info("X-Okapi-Permissions populated: permissions = {}", permissions);
+    log.info("X-Okapi-Permissions populated: permissions = {}, userId = {}", permissions, userId);
     return rc;
   }
 }

--- a/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/DesiredPermissionsFilter.java
@@ -1,7 +1,6 @@
 package org.folio.sidecar.service.filter;
 
 import static io.vertx.core.Future.succeededFuture;
-import static java.lang.String.join;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.PERMISSIONS;
 import static org.folio.sidecar.utils.CollectionUtils.isEmpty;
 import static org.folio.sidecar.utils.RoutingUtils.getPermissionsDesired;
@@ -10,6 +9,7 @@ import static org.folio.sidecar.utils.RoutingUtils.getUserIdHeader;
 import static org.folio.sidecar.utils.RoutingUtils.hasPermissionsDesired;
 
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
@@ -59,9 +59,9 @@ public class DesiredPermissionsFilter implements IngressRequestFilter {
       return rc;
     }
 
-    var perms = join(",", permissions);
+    var perms = new JsonArray(permissions).encode();
     rc.request().headers().set(PERMISSIONS, perms);
-    log.info("X-Okapi-Permissions populated: permissions = {}", perms);
+    log.info("X-Okapi-Permissions populated: permissions = {}", permissions);
     return rc;
   }
 }

--- a/src/test/resources/mappings/mod-foo-0.2.1.json
+++ b/src/test/resources/mappings/mod-foo-0.2.1.json
@@ -205,7 +205,7 @@
             "matches": "\\d{6}/bar"
           },
           "X-Okapi-Permissions": {
-            "equalTo": "bar.foo.desired.get,bar.foo.desired.post,bar.foo.item.get"
+            "equalTo": "[\"bar.foo.desired.get\",\"bar.foo.desired.post\",\"bar.foo.item.get\"]"
           }
         }
       },


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODSIDECAR-38
X-okapi-permissions header format that is populated by sidecar is wrong. 

## Approach

- change header format


## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
