### PR TITLE
MODSIDECAR-42: Dockerfile apk upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17
 FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY target/quarkus-app/lib/ ${JAVA_APP_DIR}/lib/


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODSIDECAR-42

Run apk upgrade in the Dockerfile.

apk upgrade upgrades

* libcrypto3 from 3.0.8-r0 to 3.0.12-r5 and
* libssl3 from 3.0.8-r0 to 3.0.12-r5

These two upgrades fix

* https://nvd.nist.gov/vuln/detail/CVE-2023-0464 (7.5 high)
* https://nvd.nist.gov/vuln/detail/CVE-2023-5363 (7.5 high)
* https://nvd.nist.gov/vuln/detail/CVE-2023-0465
* https://nvd.nist.gov/vuln/detail/CVE-2023-0466
* https://nvd.nist.gov/vuln/detail/CVE-2023-1255
* https://nvd.nist.gov/vuln/detail/CVE-2023-2650
* https://nvd.nist.gov/vuln/detail/CVE-2023-2975
* https://nvd.nist.gov/vuln/detail/CVE-2023-3446
* https://nvd.nist.gov/vuln/detail/CVE-2023-3817
* https://nvd.nist.gov/vuln/detail/CVE-2023-5678
* https://nvd.nist.gov/vuln/detail/CVE-2023-6129
* https://nvd.nist.gov/vuln/detail/CVE-2023-6237
* https://nvd.nist.gov/vuln/detail/CVE-2024-0727
* https://nvd.nist.gov/vuln/detail/CVE-2024-2511

apk upgrade upgrades libexpat from 2.5.0-r0 to 2.6.2-r0 fixing

* https://nvd.nist.gov/vuln/detail/CVE-2023-52425 (7.5 high)
* https://nvd.nist.gov/vuln/detail/CVE-2024-28757
* https://nvd.nist.gov/vuln/detail/CVE-2023-52426