### PR TITLE
AwsStore trust store loading fixed in folio-secret-store.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>3.6.9</quarkus.platform.version>
-    <applications-poc-tools.version>1.5.3-SNAPSHOT</applications-poc-tools.version>
+    <applications-poc-tools.version>1.5.3</applications-poc-tools.version>
     <cloudwatch.version>6.6.0</cloudwatch.version>
 
     <lombok.version>1.18.32</lombok.version>


### PR DESCRIPTION
AwsStore trust store loading fixed in folio-secret-store. Switched to the release version of the applications-poc-tools
