### PR TITLE
MODSIDECAR-66: handle X-Okapi-Token null value as absence of token

### DIFF
--- a/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
@@ -1,6 +1,8 @@
 package org.folio.sidecar.service.routing;
 
 import static org.folio.sidecar.model.ScRoutingEntry.GATEWAY_INTERFACE_ID;
+import static org.folio.sidecar.utils.RoutingUtils.hasHeaderWithValue;
+import static org.folio.sidecar.utils.RoutingUtils.hasUserIdHeader;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.http.HttpServerRequest;
@@ -110,7 +112,7 @@ public class EgressRequestHandler implements RequestHandler {
   }
 
   private boolean requireSystemUserToken(RoutingContext rc) {
-    return !RoutingUtils.hasUserIdHeader(rc) || !RoutingUtils.hasHeader(rc, OkapiHeaders.TOKEN);
+    return !hasUserIdHeader(rc) || !hasHeaderWithValue(rc, OkapiHeaders.TOKEN, true);
   }
 
   private void forwardRequest(RoutingContext rc, HttpServerRequest rq, ScRoutingEntry routingEntry,

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -161,6 +161,15 @@ public class RoutingUtils {
     return rc.request().headers().contains(header);
   }
 
+  public static boolean hasHeaderWithValue(RoutingContext rc, String header, boolean ensureNonNullValue) {
+    if (!hasHeader(rc, header)) {
+      return false;
+    }
+    var headerValue = rc.request().headers().get(header);
+    return headerValue != null && !StringUtils.isBlank(headerValue) && (!ensureNonNullValue
+      || !headerValue.trim().equalsIgnoreCase("null"));
+  }
+
   public static void setUserIdHeader(RoutingContext rc, String userId) {
     rc.request().headers().set(USER_ID, userId);
   }

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -166,8 +166,7 @@ public class RoutingUtils {
       return false;
     }
     var headerValue = rc.request().headers().get(header);
-    return headerValue != null && !StringUtils.isBlank(headerValue) && (!ensureNonNullValue
-      || !headerValue.trim().equalsIgnoreCase("null"));
+    return !StringUtils.isBlank(headerValue) && (!ensureNonNullValue || !headerValue.trim().equalsIgnoreCase("null"));
   }
 
   public static void setUserIdHeader(RoutingContext rc, String userId) {

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -31,7 +31,7 @@ class RoutingUtilsTest {
   }
 
   @Test
-  void hasHeaderWithValue_positive_nullcheck() {
+  void hasHeaderWithValue_positive_nullCheck() {
     var routingContext = routingContext("111111/users", Map.of("X-Okapi-Token", "null"));
     assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", false)).isTrue();
     assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", true)).isFalse();

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -28,6 +28,13 @@ class RoutingUtilsTest {
     assertThat(actual).isNotNull().matches("111111/users;\\d{6}/foo");
   }
 
+  @Test
+  void hasHeaderWithValue_positive_nullcheck() {
+    var routingContext = routingContext("111111/users");
+    var actual = RoutingUtils.getRequestId(routingContext);
+    assertThat(actual).isNotNull().matches("111111/users;\\d{6}/foo");
+  }
+
   private static RoutingContext routingContext(String requestId) {
     var routingContext = mock(RoutingContext.class);
     var request = mock(HttpServerRequest.class);

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -16,32 +19,40 @@ class RoutingUtilsTest {
 
   @Test
   void getRequestId_positive_newRequest() {
-    var routingContext = routingContext(null);
+    var routingContext = routingContext(null, null);
     var actual = RoutingUtils.getRequestId(routingContext);
     assertThat(actual).isNotNull().matches("\\d{6}/foo");
   }
 
   @Test
   void getRequestId_positive_nextRequest() {
-    var routingContext = routingContext("111111/users");
+    var routingContext = routingContext("111111/users", null);
     var actual = RoutingUtils.getRequestId(routingContext);
     assertThat(actual).isNotNull().matches("111111/users;\\d{6}/foo");
   }
 
   @Test
   void hasHeaderWithValue_positive_nullcheck() {
-    var routingContext = routingContext("111111/users");
-    var actual = RoutingUtils.getRequestId(routingContext);
-    assertThat(actual).isNotNull().matches("111111/users;\\d{6}/foo");
+    var routingContext = routingContext("111111/users", Map.of("X-Okapi-Token", "null"));
+    assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", false)).isTrue();
+    assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", true)).isFalse();
   }
 
-  private static RoutingContext routingContext(String requestId) {
+  private static RoutingContext routingContext(String requestId, Map<String, String> headers) {
     var routingContext = mock(RoutingContext.class);
     var request = mock(HttpServerRequest.class);
     when(routingContext.request()).thenReturn(request);
     when(request.method()).thenReturn(HttpMethod.GET);
     when(request.path()).thenReturn("/foo/entities");
     when(request.getHeader(OkapiHeaders.REQUEST_ID)).thenReturn(requestId);
+    var headersMap = new HeadersMultiMap();
+    when(request.headers()).thenReturn(headersMap);
+    if (headers != null) {
+      for (Map.Entry<String, String> header : headers.entrySet()) {
+        headersMap.set(header.getKey(), header.getValue());
+        when(request.getHeader(header.getKey())).thenReturn(header.getValue());
+      }
+    }
     return routingContext;
   }
 }

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;


### PR DESCRIPTION
## Purpose

Consider X-Okapi-Token header with null value (including literal string "null") as an absence of X-Okapi-Token header - in order to provide system user token for proxied request in such case. This is necessary because some clients use auto-generated client code, where they cannot control sending of X-Okapi-Token header conditionally, and it may be sent empty or with null value when it should be absent.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [x] Code coverage on new code is 80% or greater
    - [x] Duplications on new code is 3% or less
    - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
