### PR TITLE
MODSIDECAR-67: remove redundant interactions with x-okapi-module-id

### DIFF
--- a/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
@@ -79,8 +79,6 @@ public class EgressRequestHandler implements RequestHandler {
       return;
     }
 
-    RoutingUtils.setHeader(rc, OkapiHeaders.MODULE_ID, moduleId);
-
     authenticateAndForwardRequest(rc, rq, routingEntry);
   }
 

--- a/src/main/java/org/folio/sidecar/service/routing/IngressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/IngressRequestHandler.java
@@ -43,7 +43,6 @@ public class IngressRequestHandler implements RequestHandler {
 
     var headers = request.headers();
     headers.set(OkapiHeaders.URL, sidecarProperties.getUrl());
-    headers.set(OkapiHeaders.MODULE_ID, moduleProperties.getId());
     rc.put("uct", System.currentTimeMillis());
 
     var path = pathProcessor.getModulePath(rc.request().path());

--- a/src/test/java/org/folio/sidecar/it/ForwardUnknownEgressIT.java
+++ b/src/test/java/org/folio/sidecar/it/ForwardUnknownEgressIT.java
@@ -83,6 +83,30 @@ class ForwardUnknownEgressIT {
   }
 
   @Test
+  void handleEgressRequest_positive_multipleInterfaceType_forwardUnknown() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.MODULE_ID, "mod-qux-0.0.1")
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .get("/entities")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .statusCode(is(SC_OK))
+      .contentType(is(APPLICATION_JSON))
+      .body(
+        "totalRecords", is(2),
+        "entities[0].id", is("d22c8c0c-d387-4bd5-9ad6-c02b41abe4ec"),
+        "entities[0].name", is("Test entity 1"),
+        "entities[0].description", is("A Test entity 1 description"),
+        "entities[1].id", is("d23c8c0c-d387-4bd5-9ad6-c02b41abe4ec"),
+        "entities[1].name", is("Test entity 2"),
+        "entities[1].description", is("A Test entity 2 description")
+      );
+  }
+
+  @Test
   void handleEgressRequest_positive_forwardUnknown() {
     TestUtils.givenJson()
       .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
@@ -101,6 +125,20 @@ class ForwardUnknownEgressIT {
         "entities[0].name", is("Test entity 3"),
         "entities[0].description", is("A Test entity 3 description")
       );
+  }
+
+  @Test
+  void handleEgressRequest_positive_noModuleIdHeader() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .get("/bar/no-module-id-header")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .statusCode(is(SC_OK))
+      .contentType(is(APPLICATION_JSON));
   }
 
   public static final class ForwardUnknownTestProfile extends CommonIntegrationTestProfile {

--- a/src/test/java/org/folio/sidecar/it/SidecarIT.java
+++ b/src/test/java/org/folio/sidecar/it/SidecarIT.java
@@ -594,4 +594,18 @@ class SidecarIT {
       .log().ifValidationFails(LogDetail.ALL)
       .statusCode(is(SC_OK));
   }
+
+  @Test
+  void handleIngressRequest_positive_noModuleIdHeader() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .get("/foo/no-module-id-header")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .statusCode(is(SC_OK))
+      .contentType(is(APPLICATION_JSON));
+  }
 }

--- a/src/test/java/org/folio/sidecar/service/routing/EgressRequestHandlerTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/EgressRequestHandlerTest.java
@@ -88,7 +88,6 @@ class EgressRequestHandlerTest {
 
     egressRequestHandler.handle(rc, routingEntry());
 
-    verify(requestHeaders).set(OkapiHeaders.MODULE_ID, MODULE_ID);
     verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SERVICE_TOKEN);
     verify(requestHeaders).set(OkapiHeaders.TOKEN, USER_TOKEN);
     verify(requestHeaders).remove(OkapiHeaders.USER_ID);
@@ -111,7 +110,6 @@ class EgressRequestHandlerTest {
 
     egressRequestHandler.handle(rc, routingEntry());
 
-    verify(requestHeaders).set(OkapiHeaders.MODULE_ID, MODULE_ID);
     verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SERVICE_TOKEN);
     verify(requestHeaders).contains(OkapiHeaders.USER_ID);
     verify(requestForwardingService).forwardEgress(rc, absoluteUrl);
@@ -132,7 +130,6 @@ class EgressRequestHandlerTest {
 
     egressRequestHandler.handle(rc, routingEntry());
 
-    verify(requestHeaders).set(OkapiHeaders.MODULE_ID, MODULE_ID);
     verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SERVICE_TOKEN);
     verify(requestHeaders).set(OkapiHeaders.TOKEN, USER_TOKEN);
     verify(requestHeaders).remove(OkapiHeaders.USER_ID);
@@ -154,7 +151,6 @@ class EgressRequestHandlerTest {
     egressRequestHandler.handle(rc, routingEntry());
 
     verify(requestForwardingService).forwardEgress(rc, absoluteUrl);
-    verify(requestHeaders).set(OkapiHeaders.MODULE_ID, MODULE_ID);
     verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SERVICE_TOKEN);
     verify(requestForwardingService).forwardEgress(rc, absoluteUrl);
   }
@@ -185,7 +181,6 @@ class EgressRequestHandlerTest {
 
     egressRequestHandler.handle(rc, scGatewayEntry(TestConstants.GATEWAY_URL));
 
-    verify(requestHeaders).set(OkapiHeaders.MODULE_ID, "NONE");
     verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SERVICE_TOKEN);
     verify(requestHeaders).set(OkapiHeaders.TOKEN, USER_TOKEN);
     verify(requestHeaders).remove(OkapiHeaders.USER_ID);

--- a/src/test/java/org/folio/sidecar/service/routing/IngressRequestHandlerTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/IngressRequestHandlerTest.java
@@ -73,9 +73,8 @@ class IngressRequestHandlerTest {
     verify(moduleProperties).getUrl();
     verify(requestForwardingService).forwardIngress(routingContext, TestConstants.MODULE_URL + routingPath);
 
-    assertThat(headers).hasSize(2);
+    assertThat(headers).hasSize(1);
     assertThat(headers.get(OkapiHeaders.URL)).isEqualTo(SIDECAR_URL);
-    assertThat(headers.get(OkapiHeaders.MODULE_ID)).isEqualTo(TestConstants.MODULE_ID);
     assertThat(headers.get(OkapiHeaders.PERMISSIONS_REQUIRED)).isNull();
   }
 

--- a/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
+++ b/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
@@ -65,6 +65,11 @@
                 "methods": [ "POST" ],
                 "pathPattern": "/foo/expire/timer",
                 "permissionsRequired": []
+              },
+              {
+                "methods": [ "GET" ],
+                "pathPattern": "/foo/no-module-id-header",
+                "permissionsRequired": ["foo.no-module-id-header.get"]
               }
             ]
           },
@@ -101,6 +106,15 @@
                   "pathPattern": "/bar/entities",
                   "permissionsRequired": [
                     "item.post"
+                  ]
+                },
+                {
+                  "methods": [
+                    "GET"
+                  ],
+                  "pathPattern": "/bar/no-module-id-header",
+                  "permissionsRequired": [
+                    "bar.no-module-id-header.get"
                   ]
                 }
               ]

--- a/src/test/resources/mappings/mod-bar-0.5.1.json
+++ b/src/test/resources/mappings/mod-bar-0.5.1.json
@@ -74,6 +74,30 @@
           "description": "An entity description"
         }
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/bar/no-module-id-header",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json"
+          },
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          },
+          "X-Okapi-Module-Id": {
+            "absent": true
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Okapi-Tenant": "testtenant"
+        }
+      }
     }
   ]
 }

--- a/src/test/resources/mappings/mod-foo-0.2.1.json
+++ b/src/test/resources/mappings/mod-foo-0.2.1.json
@@ -236,6 +236,29 @@
           "X-Okapi-Tenant": "testtenant"
         }
       }
+    }, {
+      "request": {
+        "method": "GET",
+        "urlPath": "/foo/no-module-id-header",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json"
+          },
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          },
+          "X-Okapi-Module-Id": {
+            "absent": true
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Okapi-Tenant": "testtenant"
+        }
+      }
     }
   ]
 }

--- a/src/test/resources/mappings/mod-qux-0.0.1.json
+++ b/src/test/resources/mappings/mod-qux-0.0.1.json
@@ -12,7 +12,7 @@
             "equalTo": "testtenant"
           },
           "X-Okapi-Module-Id": {
-            "equalTo": "mod-qux-0.0.2"
+            "equalTo": "mod-qux-0.0.1"
           },
           "X-Okapi-Request-Id": {
             "matches": "\\d{6}/entities"


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODSIDECAR-67
We are facing an issue with the `x-okapi-module-id` header not updating as expected. It should be fixed

## Approach

- remove `x-okapi-module-id` managing while ingress request
- remove `x-okapi-module-id` managing while egress request
- add tests
- update/fix tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [x] Code coverage on new code is 80% or greater
    - [x] Duplications on new code is 3% or less
    - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [x] There are no breaking changes in this PR.
