### PR TITLE
MODSIDECAR-79 Remove X-Okapi-User-Id from evaluation if system user token required or not 

### DIFF
--- a/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/EgressRequestHandler.java
@@ -6,7 +6,6 @@ import static org.apache.logging.log4j.util.Strings.isNotBlank;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.REQUEST_ID;
 import static org.folio.sidecar.model.ScRoutingEntry.GATEWAY_INTERFACE_ID;
 import static org.folio.sidecar.utils.RoutingUtils.hasHeaderWithValue;
-import static org.folio.sidecar.utils.RoutingUtils.hasUserIdHeader;
 import static org.folio.sidecar.utils.TokenUtils.tokenHash;
 
 import io.vertx.core.Future;
@@ -87,7 +86,7 @@ public class EgressRequestHandler implements RequestHandler {
   }
 
   private boolean requireSystemUserToken(RoutingContext rc) {
-    return !hasUserIdHeader(rc) || !hasHeaderWithValue(rc, OkapiHeaders.TOKEN, true);
+    return !hasHeaderWithValue(rc, OkapiHeaders.TOKEN, true);
   }
 
   private void forwardEgressRequest(RoutingContext rc, ScRoutingEntry routingEntry) {


### PR DESCRIPTION
## Purpose

Sidecar relies on absence of X-Okapi-User-Id or X-Okapi-Token headers when it needs to understand if system user token should be obtained or not. While the last one looks like a good indicator, X-Okapi-User-Id header probably doesn't and should be removed from evaluation.
US: [MODSIDECAR-79](https://folio-org.atlassian.net/browse/MODSIDECAR-79)

## Approach
* rely only on X-Okapi-Token header when sidecar needs to understand if system user token has to be retrieved

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
    - [ ] Code coverage on new code is 80% or greater
    - [ ] Duplications on new code is 3% or less
    - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
    - [ ] Were any API paths or methods changed, added, or removed?
    - [ ] Were there any schema changes?
    - [ ] Did any of the interface versions change?
    - [ ] Were permissions changed, added, or removed?
    - [ ] Are there new interface dependencies?
    - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
    - [ ] If not, please create them
    - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
    - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
    - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
    - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
