### PR TITLE
MODSIDECAR-73: Reject requests with duplicate x-okapi-* request headers

### DIFF
--- a/src/main/java/org/folio/sidecar/service/filter/HeaderValidationFilter.java
+++ b/src/main/java/org/folio/sidecar/service/filter/HeaderValidationFilter.java
@@ -1,0 +1,57 @@
+package org.folio.sidecar.service.filter;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.log4j.Log4j2;
+import org.folio.sidecar.model.error.Error;
+import org.folio.sidecar.model.error.ErrorCode;
+import org.folio.sidecar.model.error.ErrorResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Log4j2
+@ApplicationScoped
+public class HeaderValidationFilter implements RequestFilter {
+
+  private static final String OKAPI_HEADER_PREFIX = "x-okapi-";
+
+  @Override
+  public Future<RoutingContext> filter(RoutingContext routingContext) {
+    var headers = routingContext.request().headers();
+    var duplicateOkapiHeaders = findDuplicateOkapiHeaders(headers);
+
+    if (!duplicateOkapiHeaders.isEmpty()) {
+      var errorMessage = String.format("Request contains duplicate X-Okapi headers: %s",
+        String.join(", ", duplicateOkapiHeaders));
+      
+      var error = new Error()
+        .type("ValidationError")
+        .code(ErrorCode.VALIDATION_ERROR)
+        .message(errorMessage);
+
+      var errorResponse = new ErrorResponse()
+        .errors(List.of(error))
+        .totalRecords(1);
+
+      routingContext.response()
+        .setStatusCode(Response.Status.BAD_REQUEST.getStatusCode())
+        .putHeader("Content-Type", "application/json")
+        .end(JsonObject.mapFrom(errorResponse).encode());
+
+      return Future.failedFuture(errorMessage);
+    }
+
+    return Future.succeededFuture(routingContext);
+  }
+
+  private List<String> findDuplicateOkapiHeaders(io.vertx.core.MultiMap headers) {
+    return headers.names().stream()
+      .filter(name -> name.toLowerCase().startsWith(OKAPI_HEADER_PREFIX))
+      .filter(name -> headers.getAll(name).size() > 1)
+      .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/org/folio/sidecar/service/filter/HeaderValidationFilterTest.java
+++ b/src/test/java/org/folio/sidecar/service/filter/HeaderValidationFilterTest.java
@@ -1,0 +1,109 @@
+package org.folio.sidecar.service.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HeaderValidationFilterTest {
+
+  private HeaderValidationFilter filter;
+
+  @Mock
+  private RoutingContext routingContext;
+  @Mock
+  private HttpServerRequest request;
+  @Mock
+  private HttpServerResponse response;
+
+  @BeforeEach
+  void setUp() {
+    filter = new HeaderValidationFilter();
+    when(routingContext.request()).thenReturn(request);
+    when(routingContext.response()).thenReturn(response);
+    when(response.setStatusCode(Response.Status.BAD_REQUEST.getStatusCode())).thenReturn(response);
+    when(response.putHeader("Content-Type", "application/json")).thenReturn(response);
+  }
+
+  @Test
+  void filter_shouldAllowRequestWithSingleOkapiHeader() {
+    var headers = MultiMap.caseInsensitiveMultiMap()
+      .add("x-okapi-tenant", "tenant1");
+    when(request.headers()).thenReturn(headers);
+
+    var result = filter.filter(routingContext);
+
+    assertTrue(result.succeeded());
+    assertEquals(routingContext, result.result());
+  }
+
+  @Test
+  void filter_shouldAllowRequestWithMultipleDistinctOkapiHeaders() {
+    var headers = MultiMap.caseInsensitiveMultiMap()
+      .add("x-okapi-tenant", "tenant1")
+      .add("x-okapi-token", "token1");
+    when(request.headers()).thenReturn(headers);
+
+    var result = filter.filter(routingContext);
+
+    assertTrue(result.succeeded());
+    assertEquals(routingContext, result.result());
+  }
+
+  @Test
+  void filter_shouldRejectRequestWithDuplicateOkapiHeaders() {
+    var headers = MultiMap.caseInsensitiveMultiMap()
+      .add("x-okapi-tenant", "tenant1")
+      .add("x-okapi-tenant", "tenant1");
+    when(request.headers()).thenReturn(headers);
+
+    var result = filter.filter(routingContext);
+
+    assertFalse(result.succeeded());
+    assertTrue(result.cause().getMessage().contains("x-okapi-tenant"));
+  }
+
+  @Test
+  void filter_shouldAllowRequestWithDuplicateNonOkapiHeaders() {
+    var headers = MultiMap.caseInsensitiveMultiMap()
+      .add("content-type", "application/json")
+      .add("content-type", "application/json")
+      .add("x-okapi-tenant", "tenant1");
+    when(request.headers()).thenReturn(headers);
+
+    var result = filter.filter(routingContext);
+
+    assertTrue(result.succeeded());
+    assertEquals(routingContext, result.result());
+  }
+
+  @Test
+  void filter_shouldRejectRequestWithMultipleDuplicateOkapiHeaders() {
+    var headers = MultiMap.caseInsensitiveMultiMap()
+      .add("x-okapi-tenant", "tenant1")
+      .add("x-okapi-tenant", "tenant1")
+      .add("x-okapi-token", "token1")
+      .add("x-okapi-token", "token1");
+    when(request.headers()).thenReturn(headers);
+
+    var result = filter.filter(routingContext);
+
+    assertFalse(result.succeeded());
+    assertTrue(result.cause().getMessage().contains("x-okapi-tenant"));
+    assertTrue(result.cause().getMessage().contains("x-okapi-token"));
+  }
+}


### PR DESCRIPTION
## Purpose
Implements MODSIDECAR-73 by adding validation to reject any requests that contain duplicate x-okapi-* headers.

## Approach
- Created HeaderValidationFilter to check for duplicate x-okapi-* headers
- Implemented comprehensive validation logic using Vert.x MultiMap
- Added detailed error response when duplicate headers are found
- Created thorough test coverage for various header scenarios

## Test Coverage
Tests include:
- Single x-okapi-* headers (positive case)
- Multiple distinct x-okapi-* headers (positive case)
- Duplicate x-okapi-* headers (negative case)
- Duplicate non-okapi headers (positive case)
- Multiple duplicate x-okapi-* headers (negative case)