### PR TITLE
Update HeaderValidatorTest to use routingContext

### DIFF
--- a/src/test/java/org/folio/sidecar/service/filter/validator/HeaderValidatorTest.java
+++ b/src/test/java/org/folio/sidecar/service/filter/validator/HeaderValidatorTest.java
@@ -1,0 +1,71 @@
+package org.folio.sidecar.service.filter.validator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.folio.sidecar.integration.okapi.OkapiHeaders;
+import org.folio.support.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class HeaderValidatorTest {
+
+  private HeaderValidator headerValidator;
+  private MultiMap headers;
+
+  @Mock
+  private RoutingContext routingContext;
+  @Mock
+  private HttpServerRequest request;
+
+  @BeforeEach
+  void setUp() {
+    headerValidator = new HeaderValidator();
+    headers = MultiMap.caseInsensitiveMultiMap();
+    when(routingContext.request()).thenReturn(request);
+    when(request.headers()).thenReturn(headers);
+  }
+
+  @Test
+  void validate_positive_blankTenant() {
+    headers.set(OkapiHeaders.TENANT, "");
+    headerValidator.validateOkapiHeaders(routingContext);
+  }
+
+  @Test
+  void validate_positive_noTenant() {
+    headerValidator.validateOkapiHeaders(routingContext);
+  }
+
+  @Test
+  void validate_positive_duplicatedTenant() {
+    headers.add(OkapiHeaders.TENANT, "tenant1");
+    headers.add(OkapiHeaders.TENANT, "tenant2");
+    
+    assertThrows(IllegalArgumentException.class, () -> headerValidator.validateOkapiHeaders(routingContext));
+  }
+
+  @Test
+  void validate_positive_validTenantAndToken() {
+    headers.set(OkapiHeaders.TENANT, "tenant1");
+    headers.set(OkapiHeaders.TOKEN, "token1");
+    
+    headerValidator.validateOkapiHeaders(routingContext);
+  }
+
+  @Test
+  void validate_positive_duplicatedToken() {
+    headers.add(OkapiHeaders.TOKEN, "token1");
+    headers.add(OkapiHeaders.TOKEN, "token2");
+    
+    assertThrows(IllegalArgumentException.class, () -> headerValidator.validateOkapiHeaders(routingContext));
+  }
+}


### PR DESCRIPTION
## Overview
This PR updates the HeaderValidatorTest class to use RoutingContext instead of directly working with headers. The changes include:

- Added Mockito mocks for RoutingContext and HttpServerRequest
- Updated setUp method to configure mocks
- Modified test methods to use validateOkapiHeaders with RoutingContext
- Kept the same test scenarios but adapted them to use the new approach

## Test Coverage
All existing test cases are preserved and continue to test the same functionality:
- Blank tenant validation
- No tenant validation
- Duplicated tenant validation
- Valid tenant and token validation
- Duplicated token validation

Created by EPAM AI/Run CodeMie.