### PR TITLE
MODSIDECAR-104: Reverted HTTP chunked mode for the response.

### DIFF
--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -213,7 +213,6 @@ public class RequestForwardingService {
 
     // Set the maximum write queue size to prevent memory overflow
     httpServerResponse.setWriteQueueMaxSize(128 * 1024); // 128 KB buffer
-    httpServerResponse.setChunked(true);
 
     // Attach drainHandler to resume reading when the queue has space
     httpServerResponse.drainHandler(v -> {


### PR DESCRIPTION
Reverted HTTP chunked mode for the response. The end service producing the stream must provide the proper header.
