### PR TITLE
MODSIDECAR-105: The final pull request to consolidate all necessary changes for improving TLS performance.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
 ## Version `v3.1.0` (in progress)
 ### Changes:
 * Fixed port isn't in range issue (MODSIDECAR-108)
+* Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3. (MODSIDECAR-105)

--- a/src/main/java/org/folio/sidecar/configuration/WebClientConfiguration.java
+++ b/src/main/java/org/folio/sidecar/configuration/WebClientConfiguration.java
@@ -100,6 +100,7 @@ public class WebClientConfiguration {
     var result = new WebClientOptions()
       .setName(settings.name())
       .setDecompressionSupported(settings.decompression())
+      .setKeepAlive(true)
       // timeouts
       .setConnectTimeout(settings.timeout().connect())
       .setKeepAliveTimeout(settings.timeout().keepAlive())
@@ -119,10 +120,20 @@ public class WebClientConfiguration {
     if (tls.enabled()) {
       if (tls.trustStorePath().isEmpty()) {
         log.debug("Creating web client for Public Trusted Certificates: clientName = {}", settings.name());
-        result.setSsl(true).setTrustAll(false);
+        result.setSsl(true)
+          .setReuseAddress(true)
+          .setReusePort(true)
+          .setTcpKeepAlive(true)
+          .setTrustAll(false);
       } else {
         result.setVerifyHost(tls.verifyHostname())
-          .setSsl(true).setTrustAll(false)
+          .setSsl(true)
+          .setReuseAddress(true)
+          .removeEnabledSecureTransportProtocol("TLSv1.3")
+          .addEnabledSecureTransportProtocol("TLSv1.2")
+          .setReusePort(true)
+          .setTcpKeepAlive(true)
+          .setTrustAll(false)
           .setTrustOptions(new KeyStoreOptions()
             .setPassword(getRequired(tls.trustStorePassword(), "trust-store-password", settings.name()))
             .setPath(getRequired(tls.trustStorePath(), "trust-store-path", settings.name()))


### PR DESCRIPTION
Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3.

[MODSIDECAR-105](https://folio-org.atlassian.net/browse/MODSIDECAR-105)

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.