### PR TITLE
MODSIDECAR-108: support flexible request schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,4 @@
 ### Changes:
 * Fixed port isn't in range issue (MODSIDECAR-108)
 * Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3. (MODSIDECAR-105)
+* Support flexible request schema (MODSIDECAR-108)

--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -259,9 +259,9 @@ public class RequestForwardingService {
 
   private static int getPortOrElseDefault(URI httpUri) {
     int port;
-    if (httpUri.getPort() == -1 && "http".equals(httpUri.getScheme())) {
+    if (httpUri.getPort() == -1 && "http".equalsIgnoreCase(httpUri.getScheme())) {
       port = 80;
-    } else if (httpUri.getPort() == -1 && "https".equals(httpUri.getScheme())) {
+    } else if (httpUri.getPort() == -1 && "https".equalsIgnoreCase(httpUri.getScheme())) {
       port = 443;
     } else {
       port = httpUri.getPort();

--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -14,6 +14,7 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
@@ -171,9 +172,18 @@ public class RequestForwardingService {
 
   private static Future<HttpClientRequest> createHttpClientRequestFuture(HttpClient httpClient,
     HttpServerRequest httpServerRequest, URI httpUri, QueryStringEncoder encoder) {
-    return httpUri.getPort() == -1
-      ? httpClient.request(httpServerRequest.method(), httpUri.getHost(), encoder.toString())
-      : httpClient.request(httpServerRequest.method(), httpUri.getPort(), httpUri.getHost(), encoder.toString());
+
+    var requestOptions = new RequestOptions()
+      .setHost(httpUri.getHost())
+      .setPort(getPortOrElseDefault(httpUri))
+      .setURI(encoder.toString())
+      .setMethod(httpServerRequest.method());
+
+    if (httpUri.getScheme() != null && "https".equalsIgnoreCase(httpUri.getScheme())) {
+      requestOptions.setSsl(true);
+    }
+
+    return httpClient.request(requestOptions);
   }
 
   private String toHttpsUri(String uri) {
@@ -245,5 +255,17 @@ public class RequestForwardingService {
 
     httpClientResponse.exceptionHandler(error ->
       result.fail(new InternalServerErrorException("Failed to proxy request: upstream issue", error)));
+  }
+
+  private static int getPortOrElseDefault(URI httpUri) {
+    int port;
+    if (httpUri.getPort() == -1 && "http".equals(httpUri.getScheme())) {
+      port = 80;
+    } else if (httpUri.getPort() == -1 && "https".equals(httpUri.getScheme())) {
+      port = 443;
+    } else {
+      port = httpUri.getPort();
+    }
+    return port;
   }
 }

--- a/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
@@ -190,6 +190,7 @@ class RequestForwardingServiceTest {
     when(response.headers()).thenReturn(headersResponse);
     when(headersResponse.addAll(responseHeadersMapCaptor.capture())).thenReturn(headersResponse);
 
+    service.forwardIngress(routingContext, baseUrl + PATH);
     verify(httpClient).request(argThat(options ->
       "sc-foo".equals(options.getHost())
         && port == options.getPort()

--- a/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
@@ -190,7 +190,12 @@ class RequestForwardingServiceTest {
     when(response.headers()).thenReturn(headersResponse);
     when(headersResponse.addAll(responseHeadersMapCaptor.capture())).thenReturn(headersResponse);
 
-    service.forwardIngress(routingContext, baseUrl + PATH);
+    verify(httpClient).request(argThat(options ->
+      "sc-foo".equals(options.getHost())
+        && port == options.getPort()
+        && encoder.toString().equals(options.getURI())
+        && POST == options.getMethod()
+        && sslEnabled == isTrue(options.isSsl())));
   }
 
   @Test


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODSIDECAR-108

The following request is after fixing the port not in the range issue to support a flexible request schema (`http` \ `https`). 
### **Approach**

- change building requests
- fix tests

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
