### PR TITLE
MODSIDECAR-117: Problems routing requests to interfaces of type multiple

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,4 @@
 ### Changes:
 * Fixed port isn't in range issue (MODSIDECAR-108)
 * Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3. (MODSIDECAR-105)
+* Fixed problems routing requests to interfaces of type multiple (MODSIDECAR-117)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,4 +3,4 @@
 * Fixed port isn't in range issue (MODSIDECAR-108)
 * Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3. (MODSIDECAR-105)
 * Support flexible request schema (MODSIDECAR-108)
-* * Fixed problems routing requests to interfaces of type multiple (MODSIDECAR-117)
+* Fixed problems routing requests to interfaces of type multiple (MODSIDECAR-117)

--- a/src/main/java/org/folio/sidecar/service/routing/lookup/RoutingLookupUtils.java
+++ b/src/main/java/org/folio/sidecar/service/routing/lookup/RoutingLookupUtils.java
@@ -123,12 +123,14 @@ class RoutingLookupUtils {
 
   private static boolean matchModuleIdForMultipleInterface(ScRoutingEntry candidate, HttpServerRequest request,
     boolean isSupportMultipleInterface) {
-    if (!isSupportMultipleInterface) {
-      return true;
-    }
 
     var moduleIdHeader = request.getHeader(OkapiHeaders.MODULE_ID);
     var interfaceType = candidate.getInterfaceType();
+
+    if (!isSupportMultipleInterface && !isEmpty(moduleIdHeader)) {
+      return !Objects.equals(MULTIPLE_INTERFACE_TYPE, interfaceType)
+        || Objects.equals(moduleIdHeader, candidate.getModuleId());
+    }
 
     if (isEmpty(moduleIdHeader)) {
       return !Objects.equals(MULTIPLE_INTERFACE_TYPE, interfaceType);

--- a/src/test/java/org/folio/sidecar/support/TestConstants.java
+++ b/src/test/java/org/folio/sidecar/support/TestConstants.java
@@ -30,6 +30,8 @@ public class TestConstants {
   public static final String APPLICATION_ID = "application-0.0.1";
   public static final ModuleBootstrap MODULE_BOOTSTRAP =
     parse(readString("json/module-bootstrap.json"), ModuleBootstrap.class);
+  public static final ModuleBootstrap MODULE_BOOTSTRAP_MULTI =
+    parse(readString("json/module-bootstrap-multi.json"), ModuleBootstrap.class);
   public static final ModuleBootstrap MODULE_BOOTSTRAP_EGRESS =
     parse(readString("json/module-bootstrap-egress.json"), ModuleBootstrap.class);
   public static final String AUTH_TOKEN = "dGVzdC1hY2Nlc3MtdG9rZW4=";

--- a/src/test/java/org/folio/sidecar/support/TestValues.java
+++ b/src/test/java/org/folio/sidecar/support/TestValues.java
@@ -41,6 +41,13 @@ public class TestValues {
       TestConstants.MODULE_ID, TestConstants.MODULE_URL, interfaceId, "system", routingEntry(pathPattern, methods));
   }
 
+  public static ScRoutingEntry scRoutingEntryMultiInterface(String interfaceId, String pathPattern,
+                                                          HttpMethod... httpMethods) {
+    var methods = Arrays.stream(httpMethods).map(HttpMethod::name).toArray(String[]::new);
+    return ScRoutingEntry.of(
+      TestConstants.MODULE_ID, TestConstants.MODULE_URL, interfaceId, "multiple", routingEntry(pathPattern, methods));
+  }
+
   public static ModuleBootstrapEndpoint routingEntry(String pathPattern, String[] methods) {
     var routingEntry = new ModuleBootstrapEndpoint();
     routingEntry.setPathPattern(pathPattern);

--- a/src/test/resources/json/module-bootstrap-multi.json
+++ b/src/test/resources/json/module-bootstrap-multi.json
@@ -1,0 +1,101 @@
+{
+  "module": {
+    "moduleId": "mod-foo-0.2.1",
+    "applicationId": "application-0.0.1",
+    "location": "http://sc-foo:8081",
+    "interfaces": [
+      {
+        "id": "foo",
+        "version": "0.1",
+        "interfaceType": "multiple",
+        "endpoints": [
+          {
+            "methods": [ "GET", "POST" ],
+            "pathPattern": "/foo/entities"
+          },
+          {
+            "methods": [ "GET" ],
+            "pathPattern": "/foo/entities/{id}"
+          },
+          {
+            "methods": [ "PUT" ],
+            "pathPattern": "/foo/entities/{id}"
+          },
+          {
+            "methods": [ "DELETE" ],
+            "pathPattern": "/foo/entities/{id}"
+          },
+          {
+            "methods": [ "POST" ],
+            "pathPattern": "/foo/entities"
+          },
+          {
+            "methods": [ "POST" ],
+            "pathPattern": "/foo/{fooId}/sub-entities"
+          },
+          {
+            "methods": [ "GET", "PUT" ],
+            "pathPattern": "/foo/{fooId}/sub-entities/{subEntityId}"
+          },
+          {
+            "methods": [ "PATCH" ],
+            "pathPattern": "/foo/{foo-id}/sub-entities-2/{sub-entity-id}"
+          },
+          {
+            "methods": [ "PUT", "PATCH" ],
+            "pathPattern": "/foo/{id}/entities"
+          }
+        ]
+      },
+      {
+        "id": "foo2",
+        "version": "0.3",
+        "interfaceType": "multiple",
+        "endpoints": [
+          {
+            "methods": [ "*" ],
+            "pathPattern": "/foo2*"
+          }
+        ]
+      },
+      {
+        "id": "foo3",
+        "version": "0.1",
+        "interfaceType": "multiple",
+        "endpoints": [
+          {
+            "methods": [ "GET" ],
+            "path": "/foo3/values"
+          },
+          {
+            "path": "/foo3/samples"
+          }
+        ]
+      }
+    ]
+  },
+  "requiredModules": [
+    {
+      "moduleId": "mod-bar-0.5.1",
+      "applicationId": "application-0.0.1",
+      "location": "http://mod-bar:8081",
+      "interfaces": [
+        {
+          "id": "bar",
+          "version": "0.1",
+          "endpoints": [
+            {
+              "methods": [
+                "POST"
+              ],
+              "pathPattern": "/bar/entities",
+              "permissionsRequired": [
+                "item.post"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### **Purpose**
see [MODSIDECAR-117](https://folio-org.atlassian.net/browse/MODSIDECAR-117)
Sidecar logic for determining if the request in ingress or egress, considers the interface type (multiple in this case), but does not consider the X-Okapi-Module-Id.

### **Approach**
- use X-Okapi-Module-Id to match routing entries

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
