### PR TITLE
MODSIDECAR-120: Excludes the Transfer-Encoding: chunked header when making GET or HEAD requests.

### DIFF
--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -125,7 +125,6 @@ public class RequestForwardingService {
 
       // Set the maximum write queue size to prevent memory overflow
       httpClientRequest.setWriteQueueMaxSize(128 * 1024); // 128 KB buffer
-      httpClientRequest.setChunked(true);
 
       // Attach drainHandler to resume reading when the queue has space
       httpClientRequest.drainHandler(v -> {
@@ -136,6 +135,7 @@ public class RequestForwardingService {
       // If the write queue is full, pause the ReadStream
       Set<HttpMethod> nonBodyMethods = Set.of(HttpMethod.GET, HttpMethod.HEAD);
       if (!nonBodyMethods.contains(httpServerRequest.method())) {
+        httpClientRequest.setChunked(true);
         httpServerRequest.handler(buffer -> {
           if (httpClientRequest.writeQueueFull()) {
             httpServerRequest.pause();


### PR DESCRIPTION
Exclude the Transfer-Encoding: chunked header for HTTP methods that do not expect a body, such as GET and HEAD

[MODSIDECAR-120](https://folio-org.atlassian.net/browse/MODSIDECAR-120)



### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
