### PR TITLE
BF-1070 Improve request tracing by adding response time header and Apache-like logging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,4 @@
 * Restrict the Vertex WebClient to use only TLSv1.2 to enable TLS session resumption, as the BouncyCastle library currently does not support this feature for TLSv1.3. (MODSIDECAR-105)
 * Support flexible request schema (MODSIDECAR-108)
 * Fixed problems routing requests to interfaces of type multiple (MODSIDECAR-117)
+* Improve request tracing by adding response time header and Apache-like logging (BF-1070)

--- a/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
@@ -13,7 +13,6 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,16 +29,21 @@ import org.folio.sidecar.service.routing.configuration.RequestHandler;
 public class RoutingService implements DiscoveryListener {
 
   private final ApplicationManagerService appManagerService;
-  private final Handler<RoutingContext> requestHandler;
+  private final List<Handler<RoutingContext>> requestHandlers;
   private final List<ModuleBootstrapListener> moduleBootstrapListeners;
   private final Map<String, ModuleType> knownModules = new HashMap<>();
   private final ModulePermissionsService modulePermissionsService;
 
   public RoutingService(ApplicationManagerService appManagerService,
-    @RequestHandler Instance<Handler<RoutingContext>> requestHandler, @All List<ModuleBootstrapListener> mbListeners,
+    @RequestHandler @All List<Handler<RoutingContext>> requestHandlers, @All List<ModuleBootstrapListener> mbListeners,
     ModulePermissionsService modulePermissionsService) {
     this.appManagerService = appManagerService;
-    this.requestHandler = requestHandler.get();
+
+    if (requestHandlers.isEmpty()) {
+      throw new IllegalArgumentException("Request handlers are not configured");
+    }
+    this.requestHandlers = requestHandlers;
+
     this.moduleBootstrapListeners = mbListeners;
     this.modulePermissionsService = modulePermissionsService;
   }
@@ -80,7 +84,8 @@ public class RoutingService implements DiscoveryListener {
 
     modulePermissionsService.putPermissions(findAllModulePermissions(moduleBootstrap));
 
-    router.route("/*").handler(requestHandler);
+    var route = router.route("/*");
+    requestHandlers.forEach(route::handler);
 
     registerKnownModules(moduleBootstrap);
   }

--- a/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
@@ -5,6 +5,7 @@ import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeTy
 import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.UPDATE;
 import static org.folio.sidecar.service.routing.RoutingService.ModuleType.PRIMARY;
 import static org.folio.sidecar.service.routing.RoutingService.ModuleType.REQUIRED;
+import static org.folio.sidecar.utils.CollectionUtils.isEmpty;
 import static org.folio.sidecar.utils.PermissionsUtils.findAllModulePermissions;
 
 import io.quarkus.arc.All;
@@ -39,7 +40,7 @@ public class RoutingService implements DiscoveryListener {
     ModulePermissionsService modulePermissionsService) {
     this.appManagerService = appManagerService;
 
-    if (requestHandlers.isEmpty()) {
+    if (isEmpty(requestHandlers)) {
       throw new IllegalArgumentException("Request handlers are not configured");
     }
     this.requestHandlers = requestHandlers;

--- a/src/main/java/org/folio/sidecar/service/routing/configuration/RoutingConfiguration.java
+++ b/src/main/java/org/folio/sidecar/service/routing/configuration/RoutingConfiguration.java
@@ -7,6 +7,10 @@ import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.arc.lookup.LookupUnlessProperty;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.LoggerFormat;
+import io.vertx.ext.web.handler.LoggerHandler;
+import io.vertx.ext.web.handler.ResponseTimeHandler;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Named;
@@ -88,6 +92,22 @@ public class RoutingConfiguration {
     log.info("Header tracing is activated: paths = {}", isEmpty(paths) ? "<all>" : paths);
 
     return new TraceHeadersHandler(new ScRequestHandler(chainedHandler, errorHandler), paths);
+  }
+
+  @RequestHandler
+  @Priority(10)
+  @ApplicationScoped
+  @LookupIfProperty(name = "routing.logger.enabled", stringValue = "true")
+  public Handler<RoutingContext> loggerHandler() {
+    return LoggerHandler.create(true, LoggerFormat.DEFAULT);
+  }
+
+  @RequestHandler
+  @Priority(9)
+  @ApplicationScoped
+  @LookupIfProperty(name = "routing.response-time.enabled", stringValue = "true")
+  public Handler<RoutingContext> responseTimeHandler() {
+    return ResponseTimeHandler.create();
   }
 
   public static class Dynamic {

--- a/src/main/java/org/folio/sidecar/service/routing/handler/TraceHeadersHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/TraceHeadersHandler.java
@@ -23,7 +23,7 @@ public class TraceHeadersHandler implements Handler<RoutingContext> {
   public void handle(RoutingContext rc) {
     var req = rc.request();
     if (pathMatched(req.path())) {
-      log.debug("""
+      log.info("""
         \n======================================
         Request: method = {}, uri = {}
         Current state of request context:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -202,6 +202,11 @@ routing.tracing.enabled=false
 # tracing potentially can be limited to specific paths
 #routing.tracing.paths[0]=permissions/users
 
+# enable/disable io.vertx.ext.web.handler.LoggerHandler
+routing.logger.enabled=false
+# enable/disable io.vertx.ext.web.handler.ResponseTimeHandler
+routing.response-time.enabled=true
+
 routing.dynamic.enabled=false
 routing.dynamic.discovery.cache.initial-capacity=5
 routing.dynamic.discovery.cache.max-size=200

--- a/src/test/java/org/folio/sidecar/it/ForwardEgressTlsIT.java
+++ b/src/test/java/org/folio/sidecar/it/ForwardEgressTlsIT.java
@@ -213,4 +213,22 @@ class ForwardEgressTlsIT {
       .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
       .body("message", is("permissions sets in x-okapi-permissions"));
   }
+
+  @Test
+  void handleEgressRequest_positive_responseWithTimeHeader() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, "dummy")
+      .get("/bar/entities")
+      .then()
+      .log().headers()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .header("x-response-time", Matchers.matchesPattern("\\d+ms"))
+      .contentType(is(APPLICATION_JSON));
+  }
 }

--- a/src/test/java/org/folio/sidecar/it/SidecarIT.java
+++ b/src/test/java/org/folio/sidecar/it/SidecarIT.java
@@ -650,4 +650,20 @@ class SidecarIT {
       .statusCode(is(SC_OK))
       .contentType(is(APPLICATION_JSON));
   }
+
+  @Test
+  void handleIngressRequest_positive_responseWithTimeHeader() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .get("/foo/entities")
+      .then()
+      .log().headers()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .statusCode(is(SC_OK))
+      .header(OkapiHeaders.TENANT, Matchers.is(TestConstants.TENANT_NAME))
+      .header("x-response-time", Matchers.matchesPattern("\\d+ms"))
+      .contentType(is(APPLICATION_JSON));
+  }
 }

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -62,8 +62,11 @@ class RoutingServiceTest {
 
   @Test
   void constructor_negative_noRequestHandlers() {
-    Assertions.assertThatThrownBy(() -> new RoutingService(appManagerService, List.of(),
-        List.of(listener1, listener2), modulePermissionsService))
+    var listeners = List.of(listener1, listener2);
+    var handlers = List.<Handler<RoutingContext>>of();
+    
+    Assertions.assertThatThrownBy(() -> new RoutingService(appManagerService, handlers,
+        listeners, modulePermissionsService))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Request handlers are not configured");
   }

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -17,7 +17,6 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import org.folio.sidecar.integration.am.ApplicationManagerService;
@@ -26,6 +25,7 @@ import org.folio.sidecar.support.TestConstants;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,13 +33,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
+@Disabled
 class RoutingServiceTest {
 
   private RoutingService routingService;
   @Mock private Route route;
   @Mock private Router router;
   @Mock private ApplicationManagerService appManagerService;
-  @Mock private Instance<Handler<RoutingContext>> instanceRequestHandler;
+  //@Mock private Instance<Handler<RoutingContext>> instanceRequestHandler;
   @Mock private Handler<RoutingContext> requestHandler;
   @Mock private ModuleBootstrapListener listener1;
   @Mock private ModuleBootstrapListener listener2;
@@ -47,8 +48,7 @@ class RoutingServiceTest {
 
   @BeforeEach
   void setUp() {
-    when(instanceRequestHandler.get()).thenReturn(requestHandler);
-    routingService = new RoutingService(appManagerService, instanceRequestHandler, List.of(listener1, listener2),
+    routingService = new RoutingService(appManagerService, List.of(requestHandler), List.of(listener1, listener2),
       modulePermissionsService);
   }
 

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.folio.sidecar.integration.am.ApplicationManagerService;
+import org.folio.sidecar.integration.am.model.ModuleBootstrap;
 import org.folio.sidecar.service.ModulePermissionsService;
 import org.folio.sidecar.support.TestConstants;
 import org.folio.support.types.UnitTest;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -78,13 +80,8 @@ class RoutingServiceTest {
 
     routingService.initRoutes(router);
 
-    listenersOrder.verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
-    listenersOrder.verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    listenersOrder.verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
-    listenersOrder.verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-
-    routeOrder.verify(route).handler(requestHandler1);
-    routeOrder.verify(route).handler(requestHandler2);
+    verifyListeners(listenersOrder, bootstrap);
+    verifyHandlers(routeOrder);
 
     verify(modulePermissionsService).putPermissions(anySet());
   }
@@ -140,5 +137,17 @@ class RoutingServiceTest {
   void updateModuleRoutes_negative_moduleNotFound() {
     routingService.updateModuleRoutes("unknown_module");
     verifyNoInteractions(appManagerService, listener1, listener2, router, route);
+  }
+
+  private void verifyHandlers(InOrder routeOrder) {
+    routeOrder.verify(route).handler(requestHandler1);
+    routeOrder.verify(route).handler(requestHandler2);
+  }
+
+  private void verifyListeners(InOrder listenersOrder, ModuleBootstrap bootstrap) {
+    listenersOrder.verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
+    listenersOrder.verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    listenersOrder.verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
+    listenersOrder.verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
   }
 }

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -19,13 +19,13 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.folio.sidecar.integration.am.ApplicationManagerService;
 import org.folio.sidecar.service.ModulePermissionsService;
 import org.folio.sidecar.support.TestConstants;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,28 +33,37 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-@Disabled
 class RoutingServiceTest {
 
   private RoutingService routingService;
   @Mock private Route route;
   @Mock private Router router;
   @Mock private ApplicationManagerService appManagerService;
-  //@Mock private Instance<Handler<RoutingContext>> instanceRequestHandler;
-  @Mock private Handler<RoutingContext> requestHandler;
+  @Mock private Handler<RoutingContext> requestHandler1;
+  @Mock private Handler<RoutingContext> requestHandler2;
   @Mock private ModuleBootstrapListener listener1;
   @Mock private ModuleBootstrapListener listener2;
   @Mock private ModulePermissionsService modulePermissionsService;
 
   @BeforeEach
   void setUp() {
-    routingService = new RoutingService(appManagerService, List.of(requestHandler), List.of(listener1, listener2),
+    routingService = new RoutingService(appManagerService,
+      List.of(requestHandler1, requestHandler2), List.of(listener1, listener2),
       modulePermissionsService);
   }
 
   @AfterEach
   void tearDown() {
-    verifyNoMoreInteractions(appManagerService, requestHandler, listener1, listener2, modulePermissionsService);
+    verifyNoMoreInteractions(appManagerService, requestHandler1, requestHandler2, listener1, listener2,
+      modulePermissionsService);
+  }
+
+  @Test
+  void constructor_negative_noRequestHandlers() {
+    Assertions.assertThatThrownBy(() -> new RoutingService(appManagerService, List.of(),
+        List.of(listener1, listener2), modulePermissionsService))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Request handlers are not configured");
   }
 
   @Test
@@ -65,6 +74,7 @@ class RoutingServiceTest {
     when(router.route("/*")).thenReturn(route);
 
     var listenersOrder = inOrder(listener1, listener2);
+    var routeOrder = inOrder(route);
 
     routingService.initRoutes(router);
 
@@ -72,8 +82,10 @@ class RoutingServiceTest {
     listenersOrder.verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
     listenersOrder.verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
     listenersOrder.verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(router).route("/*");
-    verify(route).handler(requestHandler);
+
+    routeOrder.verify(route).handler(requestHandler1);
+    routeOrder.verify(route).handler(requestHandler2);
+
     verify(modulePermissionsService).putPermissions(anySet());
   }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -90,3 +90,5 @@ web-client.gateway.tls.trust-store-file-type=JKS
 web-client.gateway.tls.trust-store-provider=SUN
 
 routing.tracing.enabled=true
+routing.logger.enabled=true
+routing.response-time.enabled=true


### PR DESCRIPTION
### **Purpose**
Improve incoming request tracing by adding response time header and Apache-like logging
US: [BF-1070](https://folio-org.atlassian.net/browse/BF-1070)

### **Approach**
* use Vert.x provided Routing Context handlers to add response time header and log request details: `io.vertx.ext.web.handler.LoggerHandler`, `io.vertx.ext.web.handler.ResponseTimeHandler`
* both handlers can be turned on/off by the appropriate application properties: `routing.logger.enabled`, `routing.response-time.enabled`

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [x] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
