### PR TITLE
Configure Mockito agent to be loaded explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <jjwt.version>0.12.6</jjwt.version>
     <wiremock.version>3.13.1</wiremock.version>
     <assertj-core.version>3.27.3</assertj-core.version>
-    <mockito-core.version>5.18.0</mockito-core.version>
+    <mockito.version>5.18.0</mockito.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <skipSurefireTests>false</skipSurefireTests>
 
@@ -73,6 +73,13 @@
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
         <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>${mockito.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -385,7 +392,7 @@
           <useSystemClassLoader>false</useSystemClassLoader>
           <groups>unit</groups>
           <skip>${skipSurefireTests}</skip>
-          <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar</argLine>
+          <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
         </configuration>
       </plugin>
 
@@ -408,7 +415,7 @@
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <maven.home>${maven.home}</maven.home>
               </systemPropertyVariables>
-              <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar</argLine>
+              <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <jjwt.version>0.12.6</jjwt.version>
     <wiremock.version>3.13.1</wiremock.version>
     <assertj-core.version>3.27.3</assertj-core.version>
-    <mockito-core.version>5.8.0</mockito-core.version>
+    <mockito-core.version>5.18.0</mockito-core.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <skipSurefireTests>false</skipSurefireTests>
 
@@ -385,6 +385,7 @@
           <useSystemClassLoader>false</useSystemClassLoader>
           <groups>unit</groups>
           <skip>${skipSurefireTests}</skip>
+          <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar</argLine>
         </configuration>
       </plugin>
 
@@ -407,6 +408,7 @@
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <maven.home>${maven.home}</maven.home>
               </systemPropertyVariables>
+              <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar</argLine>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### **Purpose**
Configure mockito agent explicitly to avoid warnings like the following:
```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/home/jenkins/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.5/byte-buddy-agent-1.17.5.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

### **Approach**
* add `-javaagent` directive with mockito agent to `argLine` configuration parameter of surefire and failsafe plugins

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
