### PR TITLE
MODSIDECAR-147: Bump quarkus-bom from 3.19.2 to 3.20.3 fixing zip bomb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Version `v3.0.10`
+### Changes:
+* Bump quarkus-bom from 3.19.2 to 3.20.3 fixing zip bomb ([MODSIDECAR-147](https://folio-org.atlassian.net/browse/MODSIDECAR-147))
+
 ## Version `v3.0.9` (17.09.2025)
 ### Changes:
 * Use SECRET_STORE_ENV, not ENV, for secure store key ([MODSIDECAR-140]https://folio-org.atlassian.net/browse/MODSIDECAR-140))

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.package.jar.add-runner-suffix>false</quarkus.package.jar.add-runner-suffix>
-    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.19.2</quarkus.platform.version>
+    <quarkus.platform.version>3.20.3</quarkus.platform.version>
     <applications-poc-tools.version>3.0.1</applications-poc-tools.version>
     <cloudwatch.version>6.6.0</cloudwatch.version>
     <bcpkix-fips.version>2.1.9</bcpkix-fips.version>
@@ -297,7 +297,7 @@
       </plugin>
 
       <plugin>
-        <groupId>io.quarkus.platform</groupId>
+        <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>


### PR DESCRIPTION
For Sunflower (b3.0).




### **Purpose**
https://folio-org.atlassian.net/browse/MODSIDECAR-147

Bump quarkus-bom from unsupported 3.19.2 to supported LTS 3.20.3 fixing zip bomb (Sunflower):

* https://quarkus.io/security/#supported-versions

This quarkus-bom bump transitively upgrades netty from 4.1.106.Final to 4.1.127.Final fixing

* https://github.com/advisories/GHSA-3p8m-j85q-pgmj - CVE-2025-58057 - Netty decompression bomb

### **Approach**
Change the quarkus version in the pom.xml file.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- n/a **New Properties / Environment Variables**— Updated README.md if new configs were added.
- n/a **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- n/a **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
