### PR TITLE
fix(deps): bump quarkus platform version from 3.31.4 to 3.32.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <quarkus.package.jar.add-runner-suffix>false</quarkus.package.jar.add-runner-suffix>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.31.4</quarkus.platform.version>
+    <quarkus.platform.version>3.32.4</quarkus.platform.version>
     <applications-poc-tools.version>3.1.0-SNAPSHOT</applications-poc-tools.version>
     <cloudwatch.version>6.6.0</cloudwatch.version>
     <bcpkix-fips.version>2.1.10</bcpkix-fips.version>

--- a/src/test/java/org/folio/sidecar/service/JsonConverterTest.java
+++ b/src/test/java/org/folio/sidecar/service/JsonConverterTest.java
@@ -104,9 +104,7 @@ class JsonConverterTest {
 
     assertThatThrownBy(() -> jsonConverter.parseResponse(httpResponse, TestClass.class))
       .isInstanceOf(BadRequestException.class)
-      .hasMessage("Failed to parse http response: Unrecognized token 'value': "
-        + "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n"
-        + " at [Source: (String)\"{\"field\":value}\"; line: 1, column: 15]");
+      .hasMessageStartingWith("Failed to parse http response: Unrecognized token 'value'");
     verify(objectMapper).readValue(INVALID_JSON_BODY, TestClass.class);
   }
 
@@ -143,9 +141,7 @@ class JsonConverterTest {
 
     assertThatThrownBy(() -> jsonConverter.parseResponse(httpResponse, typeRef))
       .isInstanceOf(BadRequestException.class)
-      .hasMessage("Failed to parse http response: Unrecognized token 'value': "
-        + "was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n"
-        + " at [Source: (String)\"{\"field\":value}\"; line: 1, column: 15]");
+      .hasMessageStartingWith("Failed to parse http response: Unrecognized token 'value'");
     verify(objectMapper).readValue(eq(INVALID_JSON_BODY), ArgumentMatchers.<TypeReference<TestClass>>any());
   }
 


### PR DESCRIPTION
### **Purpose**
Bump quarkus platform to latest version.

### **Approach**
bump quarkus platform version from 3.31.4 to 3.32.4

No migration is needed, see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.32

A small change in the JsonConverterTest is needed because the new Jackson version reports the parse failure no longer at the end of the token (column 15) but at the beginning (column 10) of the token.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- n/a **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- n/a **New Properties / Environment Variables**— Updated README.md if new configs were added.
- n/a **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- n/a **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
