### PR TITLE
Use tools.jackson for JSON processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>3.34.3</quarkus.platform.version>
-    <applications-poc-tools.version>3.1.0-SNAPSHOT</applications-poc-tools.version>
+    <applications-poc-tools.version>4.1.0-SNAPSHOT</applications-poc-tools.version>
     <cloudwatch.version>6.6.0</cloudwatch.version>
     <bcpkix-fips.version>2.1.10</bcpkix-fips.version>
 
@@ -183,6 +183,12 @@
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>3.1.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <applications-poc-tools.version>4.1.0-SNAPSHOT</applications-poc-tools.version>
     <cloudwatch.version>6.6.0</cloudwatch.version>
     <bcpkix-fips.version>2.1.10</bcpkix-fips.version>
+    <jackson.version>3.1.2</jackson.version>
 
     <lombok.version>1.18.44</lombok.version>
 
@@ -188,7 +189,7 @@
     <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>3.1.2</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/sidecar/configuration/ObjectMapperConfiguration.java
+++ b/src/main/java/org/folio/sidecar/configuration/ObjectMapperConfiguration.java
@@ -1,0 +1,37 @@
+package org.folio.sidecar.configuration;
+
+import static tools.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION;
+import static tools.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static tools.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static tools.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+@Log4j2
+@Dependent
+@RequiredArgsConstructor
+public class ObjectMapperConfiguration {
+
+  @Produces
+  @ApplicationScoped
+  @Named("objectMapper")
+  public ObjectMapper objectMapper() {
+    return JsonMapper.builder()
+      .changeDefaultPropertyInclusion(include ->
+        include.withValueInclusion(JsonInclude.Include.NON_NULL)
+          .withContentInclusion(JsonInclude.Include.NON_NULL))
+      .configure(INCLUDE_SOURCE_IN_LOCATION, true)
+      .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+      .configure(SORT_PROPERTIES_ALPHABETICALLY, false)
+      .build();
+  }
+}

--- a/src/main/java/org/folio/sidecar/integration/keycloak/configuration/KeycloakSidecarConfiguration.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/configuration/KeycloakSidecarConfiguration.java
@@ -1,6 +1,5 @@
 package org.folio.sidecar.integration.keycloak.configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,6 +10,7 @@ import org.folio.jwt.openid.JsonWebTokenParser;
 import org.folio.jwt.openid.OpenidJwtParserProvider;
 import org.folio.jwt.openid.configuration.JwtParserConfiguration;
 import org.folio.sidecar.integration.keycloak.model.TokenIntrospectionResponse;
+import tools.jackson.databind.ObjectMapper;
 
 @Log4j2
 @Dependent

--- a/src/main/java/org/folio/sidecar/service/JsonConverter.java
+++ b/src/main/java/org/folio/sidecar/service/JsonConverter.java
@@ -1,14 +1,14 @@
 package org.folio.sidecar.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.WebApplicationException;
 import lombok.RequiredArgsConstructor;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 @ApplicationScoped
 @RequiredArgsConstructor
@@ -31,7 +31,7 @@ public class JsonConverter {
 
     try {
       return objectMapper.writeValueAsString(value);
-    } catch (JsonProcessingException error) {
+    } catch (JacksonException error) {
       throw new BadRequestException("Failed to write value as json: " + error.getMessage());
     }
   }
@@ -40,8 +40,8 @@ public class JsonConverter {
    * Converts given json {@link String} object as java object.
    *
    * @param content - json {@link String} content
-   * @param type - return type as {@link TypeReference} object
-   * @param <T> - generic type for return object
+   * @param type    - return type as {@link TypeReference} object
+   * @param <T>     - generic type for return object
    * @return parsed {@link T} object from buffered http response
    */
   public <T> T fromJson(String content, TypeReference<T> type) {
@@ -51,7 +51,7 @@ public class JsonConverter {
 
     try {
       return objectMapper.readValue(content, type);
-    } catch (JsonProcessingException error) {
+    } catch (JacksonException error) {
       throw new BadRequestException(FAILED_TO_PARSE_HTTP_RESPONSE_MSG + error.getMessage());
     }
   }
@@ -60,14 +60,14 @@ public class JsonConverter {
    * Parses {@link HttpResponse} from {@link io.vertx.ext.web.client.WebClient} component.
    *
    * @param response - {@link HttpResponse} with {@link Buffer} as response content
-   * @param type - return type class
-   * @param <T> - generic type for return object
+   * @param type     - return type class
+   * @param <T>      - generic type for return object
    * @return parsed {@link T} object from buffered http response
    */
   public <T> T parseResponse(HttpResponse<Buffer> response, Class<T> type) {
     try {
       return objectMapper.readValue(getResponseBody(response), type);
-    } catch (JsonProcessingException error) {
+    } catch (JacksonException error) {
       throw new BadRequestException(FAILED_TO_PARSE_HTTP_RESPONSE_MSG + error.getMessage());
     }
   }
@@ -76,14 +76,14 @@ public class JsonConverter {
    * Parses {@link HttpResponse} from {@link io.vertx.ext.web.client.WebClient} component.
    *
    * @param response - {@link HttpResponse} with {@link Buffer} as response content
-   * @param type - return type as {@link TypeReference} object
-   * @param <T> - generic type for return object
+   * @param type     - return type as {@link TypeReference} object
+   * @param <T>      - generic type for return object
    * @return parsed {@link T} object from buffered http response
    */
   public <T> T parseResponse(HttpResponse<Buffer> response, TypeReference<T> type) {
     try {
       return objectMapper.readValue(getResponseBody(response), type);
-    } catch (JsonProcessingException error) {
+    } catch (JacksonException error) {
       throw new BadRequestException(FAILED_TO_PARSE_HTTP_RESPONSE_MSG + error.getMessage());
     }
   }

--- a/src/test/java/org/folio/sidecar/integration/keycloak/configuration/KeycloakSidecarConfigurationTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/configuration/KeycloakSidecarConfigurationTest.java
@@ -7,7 +7,6 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.folio.jwt.openid.OpenidJwtParserProvider;
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/org/folio/sidecar/service/JsonConverterTest.java
+++ b/src/test/java/org/folio/sidecar/service/JsonConverterTest.java
@@ -9,9 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import jakarta.ws.rs.BadRequestException;
@@ -28,6 +25,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +42,7 @@ class JsonConverterTest {
   @Spy private final ObjectMapper objectMapper = TestUtils.OBJECT_MAPPER;
 
   @Test
-  void toJson_positive() throws JsonProcessingException {
+  void toJson_positive() throws JacksonException {
     var actual = jsonConverter.toJson(TestClass.of(FIELD_VALUE));
     assertThat(actual).isEqualTo(JSON_BODY);
 

--- a/src/test/java/org/folio/sidecar/support/TestUtils.java
+++ b/src/test/java/org/folio/sidecar/support/TestUtils.java
@@ -3,12 +3,12 @@ package org.folio.sidecar.support;
 import static io.restassured.RestAssured.given;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static tools.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION;
+import static tools.jackson.databind.DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY;
+import static tools.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static tools.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonParser.Feature;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.specification.RequestSpecification;
 import java.io.File;
@@ -19,16 +19,23 @@ import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
 import org.folio.sidecar.service.SidecarSignatureService;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @Log4j2
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestUtils {
 
-  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-    .setSerializationInclusion(Include.NON_NULL)
-    .configure(Feature.INCLUDE_SOURCE_IN_LOCATION, true)
-    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-    .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+  public static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+    .changeDefaultPropertyInclusion(include ->
+      include.withValueInclusion(JsonInclude.Include.NON_NULL)
+        .withContentInclusion(JsonInclude.Include.NON_NULL))
+    .configure(INCLUDE_SOURCE_IN_LOCATION, true)
+    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .configure(ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+    .configure(SORT_PROPERTIES_ALPHABETICALLY, false)
+    .build();
 
   @SneakyThrows
   public static String readString(String path) {


### PR DESCRIPTION
### **Purpose**
Update the sidecar to use `tools.jackson` for JSON processing so it stays aligned with the newer shared tools dependency. Related issue: <add issue link if applicable>.

### **Approach**
Bumped `applications-poc-tools` to `4.1.0-SNAPSHOT`, added `tools.jackson.core:jackson-databind`, introduced a shared `ObjectMapper` producer, and updated JSON-related production and test code to use the new Jackson types and mapper configuration.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
