### PR TITLE
fix(logging): change authorization failure log level from debug to warn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ temp/
 .claude/
 .codemie/
 .agents/
+CLAUDE.md

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
@@ -166,7 +166,7 @@ public class KeycloakAuthorizationFilter implements IngressRequestFilter, CacheI
     }
 
     if (statusCode != OK.code()) {
-      log.debug("Failed to authorize request: {}", httpResponse.bodyAsString());
+      log.warn("Failed to authorize request: {}", httpResponse.bodyAsString());
       return failedFuture(new ForbiddenException(AUTHORIZATION_FAILURE_MSG));
     }
 


### PR DESCRIPTION
### **Purpose**
Raise authorization failure logging from debug to warn so unexpected non-200 responses from Keycloak authorization are visible in normal operational logs.
This makes production troubleshooting easier without changing authorization behavior.

### **Approach**
- change the non-OK authorization response log statement in `KeycloakAuthorizationFilter` from `debug` to `warn`
- ignore local `CLAUDE.md` workspace notes in `.gitignore`

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.