### PR TITLE
MODSIDECAR-178: Evict stale system token and signal retry on egress 401 Unauthorized

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.1.0` (in progress)
 ### Changes:
+* Invalidate system token cache on egress 401 and return 503 with Retry-After header ([MODSIDECAR-178](https://folio-org.atlassian.net/browse/MODSIDECAR-178))
 
 ## Version `v4.0.0` (16.04.2026)
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
     * [Ingress](#ingress)
     * [Egress](#egress)
     * [Access logging](#access-logging)
+* [Egress 401 Handling](#egress-401-handling)
 * [Module Entitlement Endpoint](#module-entitlement-endpoint)
 
 ## Introduction
@@ -459,6 +460,7 @@ Required when `SECRET_STORE_TYPE=FSSP`
   --data-urlencode 'client_id=sidecar-module-access-client' \
   --data-urlencode 'client_secret=supersecret'
   ```
+
 ### Access logging
 * For access logging Common Log Format(`host ident authuser date request status bytes user-agent`) is used,
 * value: `%X{remote-ip} %X{remote-host} %X{remote-user} %d{dd/MM/yyyy:HH:mm:ss z} %X{method} %X{path} %X{protocol} %X{status} %X{bytes} rt=%X{rt}  uct=%X{uct}  uht=%X{uht}  urt=%X{urt}  %X{user-agent} %X{x-okapi-tenant} %X{x-okapi-user-id} %X{x-okapi-request-id} %m%n`
@@ -482,6 +484,38 @@ Required when `SECRET_STORE_TYPE=FSSP`
 | x-okapi-tenant            | OKAPI tenant header value.                                                                                                                     |
 | x-okapi-user-id           | OKAPI user id header value.                                                                                                                    |
 | x-okapi-request-id        | OKAPI request id header value.                                                                                                                 |
+
+## Egress 401 Handling
+
+When a target module responds with `401 Unauthorized` on a module-to-module (egress) call, the
+sidecar intercepts the response before it reaches the original caller and takes the following steps:
+
+1. Drains and discards the upstream response body to cleanly release the HTTP connection.
+2. Evicts the system token for the affected tenant from the internal cache so the very next egress
+   call for that tenant will obtain a fresh token from Keycloak.
+3. Returns `503 Service Unavailable` to the original caller with a `Retry-After: 1` header.
+
+**What callers should do**
+
+Upon receiving `503 Service Unavailable` with a `Retry-After` header on an egress request, wait for
+the number of seconds indicated in the header and then retry the original request unchanged. By the
+time the retry arrives, the sidecar will have discarded the stale token; the next egress call to the
+same target will acquire a fresh one from Keycloak before forwarding.
+
+**Why the sidecar cannot retry the request itself**
+
+The sidecar cannot transparently retry egress requests for two reasons:
+
+* **Request body is already consumed.** By the time the upstream 401 is received, the original
+  request body has been forwarded to the target and is no longer held in the sidecar. Replaying the
+  request would require re-reading the body from the original caller, which is not possible in a
+  streaming proxy.
+* **Retry ownership belongs to the caller.** The sidecar has no visibility into how many times the
+  caller has already retried, what the caller's timeout budget is, or whether the operation is
+  idempotent. Retrying silently on the caller's behalf would hide the failure, could violate
+  idempotency, and risks amplifying the problem if the root cause persists (e.g. misconfigured
+  service-client credentials in Keycloak). Surfacing the failure as a `503` keeps retry logic and
+  backoff strategy under the caller's control.
 
 ## Module Entitlement Endpoint
 

--- a/src/main/java/org/folio/sidecar/exception/EgressUnauthorizedException.java
+++ b/src/main/java/org/folio/sidecar/exception/EgressUnauthorizedException.java
@@ -1,0 +1,8 @@
+package org.folio.sidecar.exception;
+
+public class EgressUnauthorizedException extends RuntimeException {
+
+  public EgressUnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/sidecar/exception/EgressUnauthorizedException.java
+++ b/src/main/java/org/folio/sidecar/exception/EgressUnauthorizedException.java
@@ -1,7 +1,15 @@
 package org.folio.sidecar.exception;
 
+/**
+ * Thrown when an upstream module returns {@code 401 Unauthorized} on a module-to-module (egress) request.
+ */
 public class EgressUnauthorizedException extends RuntimeException {
 
+  /**
+   * Constructs a new exception with the given detail message.
+   *
+   * @param message detail message describing the failing egress request
+   */
   public EgressUnauthorizedException(String message) {
     super(message);
   }

--- a/src/main/java/org/folio/sidecar/service/ErrorHandler.java
+++ b/src/main/java/org/folio/sidecar/service/ErrorHandler.java
@@ -113,7 +113,7 @@ public class ErrorHandler {
       .add(
         EgressUnauthorizedException.class, (cause, rc) ->
           sendErrorResponse(rc, cause, SERVICE_UNAVAILABLE, ErrorCode.AUTHORIZATION_ERROR,
-            "Service Unavailable. Retry latter", Map.of(RETRY_AFTER, EGRESS_UNAUTH_RETRY_DELAY)))
+            "Service Unavailable. Retry later", Map.of(RETRY_AFTER, EGRESS_UNAUTH_RETRY_DELAY)))
       .addDefault((cause, rc) ->
         sendErrorResponse(rc, cause, INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN_ERROR, null));
   }

--- a/src/main/java/org/folio/sidecar/service/ErrorHandler.java
+++ b/src/main/java/org/folio/sidecar/service/ErrorHandler.java
@@ -65,10 +65,29 @@ public class ErrorHandler {
     errHandler.handle(cause, rc);
   }
 
+  /**
+   * Sends an error response without additional headers.
+   *
+   * @param rc          routing context
+   * @param error       cause of the error
+   * @param status      HTTP status code
+   * @param code        application-level error code
+   * @param msgOverride message to use in the response body, or {@code null} to use the exception message
+   */
   private void sendErrorResponse(RoutingContext rc, Throwable error, int status, ErrorCode code, String msgOverride) {
     sendErrorResponse(rc, error, status, code, msgOverride, null);
   }
 
+  /**
+   * Sends an error response with optional additional response headers.
+   *
+   * @param rc                routing context
+   * @param error             cause of the error
+   * @param status            HTTP status code
+   * @param code              application-level error code
+   * @param msgOverride       message to use in the response body, or {@code null} to use the exception message
+   * @param additionalHeaders extra headers to include in the response, or {@code null} if none
+   */
   private void sendErrorResponse(RoutingContext rc, Throwable error, int status, ErrorCode code, String msgOverride,
     Map<String, String> additionalHeaders) {
     sidecarSignatureService.removeSignature(rc);

--- a/src/main/java/org/folio/sidecar/service/ErrorHandler.java
+++ b/src/main/java/org/folio/sidecar/service/ErrorHandler.java
@@ -1,6 +1,7 @@
 package org.folio.sidecar.service;
 
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.RETRY_AFTER;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
@@ -9,6 +10,7 @@ import static org.jboss.resteasy.reactive.RestResponse.StatusCode.BAD_REQUEST;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.FORBIDDEN;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.INTERNAL_SERVER_ERROR;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.REQUEST_TIMEOUT;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.SERVICE_UNAVAILABLE;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.UNAUTHORIZED;
 
 import io.quarkus.security.ForbiddenException;
@@ -19,11 +21,13 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import lombok.extern.log4j.Log4j2;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.exception.TenantNotEnabledException;
 import org.folio.sidecar.model.error.Error;
 import org.folio.sidecar.model.error.ErrorCode;
@@ -33,6 +37,8 @@ import org.folio.sidecar.model.error.Parameter;
 @Log4j2
 @ApplicationScoped
 public class ErrorHandler {
+
+  private static final String EGRESS_UNAUTH_RETRY_DELAY = "1"; // in seconds
 
   private final JsonConverter jsonConverter;
   private final SidecarSignatureService sidecarSignatureService;
@@ -60,6 +66,11 @@ public class ErrorHandler {
   }
 
   private void sendErrorResponse(RoutingContext rc, Throwable error, int status, ErrorCode code, String msgOverride) {
+    sendErrorResponse(rc, error, status, code, msgOverride, null);
+  }
+
+  private void sendErrorResponse(RoutingContext rc, Throwable error, int status, ErrorCode code, String msgOverride,
+    Map<String, String> additionalHeaders) {
     sidecarSignatureService.removeSignature(rc);
 
     log.warn("Sending error response for [method: {}, uri: {}]: type = {}, message = {}",
@@ -67,13 +78,18 @@ public class ErrorHandler {
 
     var response = rc.response();
     if (!response.ended()) {
-      response
-        .setStatusCode(status)
-        .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+      response.setStatusCode(status);
+
+      if (additionalHeaders != null) {
+        additionalHeaders.forEach(response::putHeader);
+      }
+
+      response.putHeader(CONTENT_TYPE, APPLICATION_JSON)
         .end(jsonConverter.toJson(buildResponseEntity(code, error, msgOverride)));
     }
   }
 
+  @SuppressWarnings("checkstyle:MethodLength")
   private ErrHandler createHandler() {
     return ErrHandler.builder()
       .add(
@@ -94,6 +110,10 @@ public class ErrorHandler {
       .add(
         TenantNotEnabledException.class, (cause, rc) ->
           sendErrorResponse(rc, cause, BAD_REQUEST, ErrorCode.UNKNOWN_TENANT, null))
+      .add(
+        EgressUnauthorizedException.class, (cause, rc) ->
+          sendErrorResponse(rc, cause, SERVICE_UNAVAILABLE, ErrorCode.AUTHORIZATION_ERROR,
+            "Service Unavailable. Retry latter", Map.of(RETRY_AFTER, EGRESS_UNAUTH_RETRY_DELAY)))
       .addDefault((cause, rc) ->
         sendErrorResponse(rc, cause, INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN_ERROR, null));
   }

--- a/src/main/java/org/folio/sidecar/service/routing/handler/EgressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/EgressRequestHandler.java
@@ -6,6 +6,7 @@ import static org.folio.sidecar.integration.okapi.OkapiHeaders.REQUEST_ID;
 import static org.folio.sidecar.model.ScRoutingEntry.GATEWAY_INTERFACE_ID;
 import static org.folio.sidecar.utils.RoutingUtils.dumpUri;
 import static org.folio.sidecar.utils.RoutingUtils.hasHeaderWithValue;
+import static org.folio.sidecar.utils.RoutingUtils.markAsEgressRequest;
 import static org.folio.sidecar.utils.TokenUtils.tokenHash;
 
 import io.vertx.core.Future;
@@ -18,6 +19,7 @@ import java.util.function.Function;
 import lombok.extern.log4j.Log4j2;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.folio.sidecar.configuration.properties.ModuleProperties;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.sidecar.model.ScRoutingEntry;
 import org.folio.sidecar.service.PathProcessor;
@@ -60,6 +62,8 @@ class EgressRequestHandler implements RoutingEntryHandler {
    */
   @Override
   public Future<Void> handle(ScRoutingEntry routingEntry, RoutingContext rc) {
+    markAsEgressRequest(rc);
+
     var rq = rc.request();
     log.debug("Handling egress request [method: {}, uri: {}, requestId: {}]",
       rq::method, dumpUri(rc), () -> rq.getHeader(REQUEST_ID));
@@ -68,7 +72,8 @@ class EgressRequestHandler implements RoutingEntryHandler {
       .map(v -> validateRoutingModuleId(routingEntry))
       .compose(v -> populateSystemToken(rc))
       .compose(v -> populateSystemUserToken(rc))
-      .compose(v -> forwardEgressRequest(rc, routingEntry));
+      .compose(v -> forwardEgressRequest(rc, routingEntry))
+      .recover(err -> invalidateServiceTokenOnUnauthorized(err, rc));
   }
 
   private Void validateRoutingModuleId(ScRoutingEntry routingEntry) {
@@ -139,5 +144,14 @@ class EgressRequestHandler implements RoutingEntryHandler {
 
       return null;
     };
+  }
+
+  private Future<Void> invalidateServiceTokenOnUnauthorized(Throwable err, RoutingContext rc) {
+    if (err instanceof EgressUnauthorizedException) {
+      var tenant = RoutingUtils.getTenant(rc);
+
+      serviceTokenProvider.invalidateToken(tenant);
+    }
+    return failedFuture(err);
   }
 }

--- a/src/main/java/org/folio/sidecar/service/routing/handler/EgressRequestHandler.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/EgressRequestHandler.java
@@ -146,6 +146,14 @@ class EgressRequestHandler implements RoutingEntryHandler {
     };
   }
 
+  /**
+   * Recovery handler that evicts the service token cache entry when an egress 401 is detected.
+   * All other errors are re-propagated unchanged.
+   *
+   * @param err error from the egress pipeline
+   * @param rc  routing context
+   * @return a failed {@link Future} carrying the original error
+   */
   private Future<Void> invalidateServiceTokenOnUnauthorized(Throwable err, RoutingContext rc) {
     if (err instanceof EgressUnauthorizedException) {
       var tenant = RoutingUtils.getTenant(rc);

--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -246,6 +246,16 @@ public class RequestForwardingService {
     removeSidecarSignatureThenEndResponse(rc, resp, response, result, httpClientRequest);
   }
 
+  /**
+   * Handles a {@code 401 Unauthorized} response received on an egress request.
+   * Drains the upstream response body to release the connection, logs the event, and fails
+   * the result promise with {@link EgressUnauthorizedException}.
+   *
+   * @param rc                routing context
+   * @param resp              upstream HTTP response
+   * @param result            promise to fail once the body is fully drained
+   * @param httpClientRequest upstream request, used for transaction logging
+   */
   private void handleEgressUnauthorized(RoutingContext rc, HttpClientResponse resp, Promise<Void> result,
     HttpClientRequest httpClientRequest) {
     log.info("Intercepted {} from upstream on egress request [method: {}, uri: {}]", () -> UNAUTHORIZED,

--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -270,6 +270,9 @@ public class RequestForwardingService {
       result.fail(new EgressUnauthorizedException("Failed to authorize egress request to: "
         + rc.request().method() + " " + dumpUri(rc).get()));
     });
+
+    resp.exceptionHandler(error ->
+      result.fail(new InternalServerErrorException("Failed to drain unauthorized upstream response", error)));
   }
 
   /**

--- a/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/handler/RequestForwardingService.java
@@ -1,9 +1,12 @@
 package org.folio.sidecar.service.routing.handler;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 import static jakarta.ws.rs.core.HttpHeaders.USER_AGENT;
 import static java.lang.String.format;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.REQUEST_ID;
+import static org.folio.sidecar.utils.RoutingUtils.dumpUri;
 import static org.folio.sidecar.utils.RoutingUtils.getRequestId;
+import static org.folio.sidecar.utils.RoutingUtils.isEgressRequest;
 
 import io.netty.handler.codec.http.QueryStringEncoder;
 import io.vertx.core.Future;
@@ -29,6 +32,7 @@ import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.folio.sidecar.configuration.properties.HttpProperties;
 import org.folio.sidecar.configuration.properties.WebClientConfig;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.service.SidecarSignatureService;
 import org.folio.sidecar.service.TransactionLogHandler;
 
@@ -229,12 +233,33 @@ public class RequestForwardingService {
 
   private void handleSuccessfulResponse(RoutingContext rc, HttpClientResponse resp, Promise<Void> result,
     HttpClientRequest httpClientRequest) {
+    if (resp.statusCode() == UNAUTHORIZED.code() && isEgressRequest(rc)) {
+      handleEgressUnauthorized(rc, resp, result, httpClientRequest);
+      return;
+    }
+
     var response = rc.response();
     response.headers().addAll(resp.headers());
     response.setStatusCode(resp.statusCode());
     rc.put("uht", System.currentTimeMillis());
 
     removeSidecarSignatureThenEndResponse(rc, resp, response, result, httpClientRequest);
+  }
+
+  private void handleEgressUnauthorized(RoutingContext rc, HttpClientResponse resp, Promise<Void> result,
+    HttpClientRequest httpClientRequest) {
+    log.info("Intercepted {} from upstream on egress request [method: {}, uri: {}]", () -> UNAUTHORIZED,
+      () -> rc.request().method(), dumpUri(rc));
+
+    // Drain upstream response body to release the connection
+    resp.handler(buf -> {});
+    resp.endHandler(v -> {
+      rc.put("urt", System.currentTimeMillis());
+      transactionLogHandler.log(rc, resp, httpClientRequest);
+
+      result.fail(new EgressUnauthorizedException("Failed to authorize egress request to: "
+        + rc.request().method() + " " + dumpUri(rc).get()));
+    });
   }
 
   /**

--- a/src/main/java/org/folio/sidecar/service/token/ServiceTokenProvider.java
+++ b/src/main/java/org/folio/sidecar/service/token/ServiceTokenProvider.java
@@ -63,6 +63,11 @@ public class ServiceTokenProvider {
     return getTokenInternal(SUPER_TENANT);
   }
 
+  /**
+   * Evicts the cached service token for the given tenant, forcing a fresh token to be obtained on the next request.
+   *
+   * @param tenant tenant whose cache entry should be invalidated
+   */
   public void invalidateToken(String tenant) {
     log.info("Invalidating service token cache for tenant: tenant = {}", tenant);
     tokenCache.synchronous().invalidate(tenant);

--- a/src/main/java/org/folio/sidecar/service/token/ServiceTokenProvider.java
+++ b/src/main/java/org/folio/sidecar/service/token/ServiceTokenProvider.java
@@ -63,6 +63,11 @@ public class ServiceTokenProvider {
     return getTokenInternal(SUPER_TENANT);
   }
 
+  public void invalidateToken(String tenant) {
+    log.info("Invalidating service token cache for tenant: tenant = {}", tenant);
+    tokenCache.synchronous().invalidate(tenant);
+  }
+
   /**
    * Obtains a service access token using client_credentials flow.
    *

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -157,10 +157,21 @@ public class RoutingUtils {
     return Boolean.TRUE.equals(rc.get(SELF_REQUEST_KEY));
   }
 
+  /**
+   * Returns {@code true} if the request has been marked as an egress (module-to-module) request.
+   *
+   * @param rc routing context
+   * @return {@code true} if this is an egress request, {@code false} otherwise
+   */
   public static boolean isEgressRequest(RoutingContext rc) {
     return Boolean.TRUE.equals(rc.get(EGRESS_REQUEST_KEY));
   }
 
+  /**
+   * Marks the request as an egress (module-to-module) request in the routing context.
+   *
+   * @param rc routing context
+   */
   public static void markAsEgressRequest(RoutingContext rc) {
     rc.put(EGRESS_REQUEST_KEY, true);
   }

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -42,6 +42,7 @@ public class RoutingUtils {
    */
   public static final String SC_ROUTING_ENTRY_KEY = "scRoutingEntry";
   public static final String SELF_REQUEST_KEY = "selfRequest";
+  public static final String EGRESS_REQUEST_KEY = "egressRequest";
   public static final String ORIGIN_TENANT = "originTenant";
   public static final String PARSED_TOKEN = "parsedToken";
   private static final int URI_MAX_LENGTH = 512;
@@ -154,6 +155,14 @@ public class RoutingUtils {
 
   public static boolean isSelfRequest(RoutingContext rc) {
     return Boolean.TRUE.equals(rc.get(SELF_REQUEST_KEY));
+  }
+
+  public static boolean isEgressRequest(RoutingContext rc) {
+    return Boolean.TRUE.equals(rc.get(EGRESS_REQUEST_KEY));
+  }
+
+  public static void markAsEgressRequest(RoutingContext rc) {
+    rc.put(EGRESS_REQUEST_KEY, true);
   }
 
   public static boolean hasNoPermissionsRequired(RoutingContext rc) {

--- a/src/test/java/org/folio/sidecar/it/ForwardEgressTlsIT.java
+++ b/src/test/java/org/folio/sidecar/it/ForwardEgressTlsIT.java
@@ -1,11 +1,13 @@
 package org.folio.sidecar.it;
 
+import static jakarta.ws.rs.core.HttpHeaders.RETRY_AFTER;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_REQUEST_TIMEOUT;
+import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.USER_TOKEN;
@@ -119,7 +121,7 @@ class ForwardEgressTlsIT {
   }
 
   @Test
-  void handleEgressRequest_negative_routeNotFoundForInvalidHttpMethod() {
+  void handleEgressRequest_negative_routeNotFoundForInvalidHttpMethod()   {
     TestUtils.givenJson()
       .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
       .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
@@ -242,6 +244,29 @@ class ForwardEgressTlsIT {
       .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
       .header("x-response-time", Matchers.matchesPattern("\\d+ms"))
       .contentType(is(APPLICATION_JSON));
+  }
+
+  @Test
+  void handleEgressRequest_negative_upstreamUnauthorizedIntercepted() {
+    TestUtils.givenJson()
+      .header(OkapiHeaders.TENANT, TestConstants.TENANT_NAME)
+      .header(OkapiHeaders.AUTHORIZATION, "Bearer " + authToken)
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, "dummy")
+      .header(OkapiHeaders.TOKEN, USER_TOKEN)
+      .get("/bar/entities/unauthorized")
+      .then()
+      .log().ifValidationFails(LogDetail.ALL)
+      .assertThat()
+      .header(TestConstants.SIDECAR_SIGNATURE_HEADER, nullValue())
+      .header(RETRY_AFTER, is("1"))
+      .statusCode(is(SC_SERVICE_UNAVAILABLE))
+      .contentType(is(APPLICATION_JSON))
+      .body(
+        "total_records", is(1),
+        "errors[0].type", is("EgressUnauthorizedException"),
+        "errors[0].code", is("authorization_error"),
+        "errors[0].message", is("Service Unavailable. Retry later")
+      );
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/ErrorHandlerTest.java
+++ b/src/test/java/org/folio/sidecar/service/ErrorHandlerTest.java
@@ -1,12 +1,12 @@
 package org.folio.sidecar.service;
 
 import static io.vertx.core.Future.succeededFuture;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.HttpHeaders.RETRY_AFTER;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +25,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import java.util.UUID;
 import org.apache.http.ParseException;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.exception.TenantNotEnabledException;
 import org.folio.sidecar.model.error.ErrorResponse;
 import org.folio.sidecar.support.TestUtils;
@@ -173,6 +174,20 @@ class ErrorHandlerTest {
   }
 
   @Test
+  void sendErrorResponse_positive_egressUnauthorizedError() {
+    var routingContext = routingContext();
+
+    errorHandler.sendErrorResponse(routingContext, new EgressUnauthorizedException("Unauthorized"));
+
+    assertThat(responseCaptor.getValue())
+      .isEqualTo(TestUtils.minify(TestUtils.readString("json/egress-unauthorized-error.json")));
+    assertThat(responseStatusCaptor.getValue()).isEqualTo(SC_SERVICE_UNAVAILABLE);
+    verify(routingContext.response()).putHeader(RETRY_AFTER, "1");
+    verify(jsonConverter).toJson(any(ErrorResponse.class));
+    verify(sidecarSignatureService).removeSignature(routingContext);
+  }
+
+  @Test
   void sendErrorResponse_positive_responseIsEnded() {
     var routingContext = mock(RoutingContext.class);
     var response = mock(HttpServerResponse.class);
@@ -193,7 +208,7 @@ class ErrorHandlerTest {
     when(routingContext.response()).thenReturn(response);
     when(routingContext.request()).thenReturn(request);
     when(response.setStatusCode(responseStatusCaptor.capture())).thenReturn(response);
-    when(response.putHeader(CONTENT_TYPE, APPLICATION_JSON)).thenReturn(response);
+    when(response.putHeader(anyString(), anyString())).thenReturn(response);
     when(response.end(responseCaptor.capture())).thenReturn(succeededFuture());
     return routingContext;
   }

--- a/src/test/java/org/folio/sidecar/service/routing/handler/EgressRequestHandlerTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/handler/EgressRequestHandlerTest.java
@@ -8,6 +8,7 @@ import static org.folio.sidecar.support.TestConstants.GATEWAY_URL;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.SYS_TOKEN;
 import static org.folio.sidecar.support.TestConstants.SYS_USER_TOKEN;
+import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.support.TestConstants.USER_TOKEN;
 import static org.folio.sidecar.support.TestValues.scGatewayEntry;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,6 +27,7 @@ import jakarta.ws.rs.BadRequestException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.folio.sidecar.configuration.properties.ModuleProperties;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.integration.am.model.ModuleBootstrapEndpoint;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.sidecar.model.ScRoutingEntry;
@@ -235,6 +237,51 @@ class EgressRequestHandlerTest {
 
       assertThat(rf.failed()).isTrue();
       assertThat(rf.cause()).hasMessage("Filter validation failed");
+    }
+
+    @Test
+    void handle_negative_egressUnauthorizedExceptionInvalidatesServiceToken() {
+      prepareHttpRequest(req -> {
+        when(req.path()).thenReturn(fooEntitiesPath);
+        when(req.getHeader(OkapiHeaders.TENANT)).thenReturn(TENANT_NAME);
+      });
+      when(requestFilterService.filterEgressRequest(rc)).thenReturn(succeededFuture(rc));
+      when(serviceTokenProvider.getToken(rc)).thenReturn(succeededFuture(SYS_TOKEN));
+      when(request.headers()).thenReturn(requestHeaders);
+      when(requestHeaders.contains(OkapiHeaders.TOKEN)).thenReturn(false);
+      when(systemUserTokenProvider.getToken(rc)).thenReturn(succeededFuture(Optional.of(SYS_USER_TOKEN)));
+      when(pathProcessor.cleanIngressRequestPath(fooEntitiesPath)).thenReturn(fooEntitiesPath);
+      var egressUnauth = new EgressUnauthorizedException("Unauthorized egress");
+      when(requestForwardingService.forwardEgress(rc, absoluteUrl)).thenReturn(failedFuture(egressUnauth));
+
+      var rf = egressRequestHandler.handle(routingEntry(), rc);
+
+      assertThat(rf.failed()).isTrue();
+      assertThat(rf.cause()).isInstanceOf(EgressUnauthorizedException.class);
+      verify(serviceTokenProvider).invalidateToken(TENANT_NAME);
+      verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SYS_TOKEN);
+      verify(requestHeaders).set(OkapiHeaders.TOKEN, SYS_USER_TOKEN);
+    }
+
+    @Test
+    void handle_negative_otherExceptionDoesNotInvalidateToken() {
+      prepareHttpRequest(req -> when(req.path()).thenReturn(fooEntitiesPath));
+      when(requestFilterService.filterEgressRequest(rc)).thenReturn(succeededFuture(rc));
+      when(serviceTokenProvider.getToken(rc)).thenReturn(succeededFuture(SYS_TOKEN));
+      when(request.headers()).thenReturn(requestHeaders);
+      when(requestHeaders.contains(OkapiHeaders.TOKEN)).thenReturn(false);
+      when(systemUserTokenProvider.getToken(rc)).thenReturn(succeededFuture(Optional.of(SYS_USER_TOKEN)));
+      when(pathProcessor.cleanIngressRequestPath(fooEntitiesPath)).thenReturn(fooEntitiesPath);
+      when(requestForwardingService.forwardEgress(rc, absoluteUrl))
+        .thenReturn(failedFuture(new RuntimeException("Upstream error")));
+
+      var rf = egressRequestHandler.handle(routingEntry(), rc);
+
+      assertThat(rf.failed()).isTrue();
+      assertThat(rf.cause()).isInstanceOf(RuntimeException.class).hasMessage("Upstream error");
+      verify(serviceTokenProvider, never()).invalidateToken(anyString());
+      verify(requestHeaders).set(OkapiHeaders.SYSTEM_TOKEN, SYS_TOKEN);
+      verify(requestHeaders).set(OkapiHeaders.TOKEN, SYS_USER_TOKEN);
     }
   }
 

--- a/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/handler/RequestForwardingServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.sidecar.service.routing.handler;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.http.HttpMethod.POST;
@@ -36,10 +37,12 @@ import jakarta.ws.rs.InternalServerErrorException;
 import java.util.function.Consumer;
 import org.folio.sidecar.configuration.properties.HttpProperties;
 import org.folio.sidecar.configuration.properties.WebClientConfig;
+import org.folio.sidecar.exception.EgressUnauthorizedException;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.sidecar.service.SidecarSignatureService;
 import org.folio.sidecar.service.TransactionLogHandler;
 import org.folio.sidecar.support.TestConstants;
+import org.folio.sidecar.utils.RoutingUtils;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -481,6 +484,43 @@ class RequestForwardingServiceTest {
     assertThat(result.failed()).isTrue();
     assertThat(result.cause()).isInstanceOf(InternalServerErrorException.class);
     assertThat(result.cause().getMessage()).isEqualTo("Failed to proxy request: Unknown error");
+  }
+
+  @Test
+  void forwardEgress_negative_unauthorizedInterceptedOnEgressRequest() {
+    var egressSettingsMock = mock(WebClientConfig.WebClientSettings.class);
+    when(webClientConfig.egress()).thenReturn(egressSettingsMock);
+    var egressTlsMock = mock(WebClientConfig.TlsSettings.class);
+    when(egressSettingsMock.tls()).thenReturn(egressTlsMock);
+    when(egressTlsMock.enabled()).thenReturn(false);
+
+    var routingContext = routingContext(rc ->
+      when(rc.get(RoutingUtils.EGRESS_REQUEST_KEY)).thenReturn(Boolean.TRUE));
+
+    var encoder = new QueryStringEncoder(PATH);
+    routingContext.request().params().forEach(encoder::addParam);
+
+    when(httpClient.request(argThat(options ->
+      "sc-foo".equals(options.getHost())
+        && 8081 == options.getPort()
+        && encoder.toString().equals(options.getURI())
+        && POST == options.getMethod())))
+      .thenReturn(succeededFuture(httpClientRequest));
+
+    when(httpProperties.getTimeout()).thenReturn(TIMEOUT);
+    when(httpClientRequest.headers()).thenReturn(headers);
+    when(headers.setAll(any(MultiMap.class))).thenReturn(headers);
+    when(httpClientRequest.response()).thenReturn(succeededFuture(httpClientResponse));
+    when(httpClientResponse.statusCode()).thenReturn(UNAUTHORIZED.code());
+    when(httpClientResponse.endHandler(responseEndHandlerCaptor.capture())).thenReturn(httpClientResponse);
+
+    var result = service.forwardEgress(routingContext, absoluteUrl);
+    responseEndHandlerCaptor.getValue().handle(null);
+
+    assertThat(result.failed()).isTrue();
+    assertThat(result.cause()).isInstanceOf(EgressUnauthorizedException.class)
+      .hasMessageContaining("Failed to authorize egress request to:");
+    verify(transactionLogHandler).log(routingContext, httpClientResponse, httpClientRequest);
   }
 
   @CsvSource({

--- a/src/test/java/org/folio/sidecar/service/token/ServiceTokenProviderTest.java
+++ b/src/test/java/org/folio/sidecar/service/token/ServiceTokenProviderTest.java
@@ -85,6 +85,16 @@ class ServiceTokenProviderTest {
   }
 
   @Test
+  void invalidateToken_positive() {
+    var loadingCache = mock(LoadingCache.class);
+    when(tokenCache.synchronous()).thenReturn(loadingCache);
+
+    service.invalidateToken(TENANT_NAME);
+
+    verify(loadingCache).invalidate(TENANT_NAME);
+  }
+
+  @Test
   void syncCache_positive() {
     var cached = Map.ofEntries(
       entry("tenant-foo", completedFuture(new TokenResponse())),

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -2,6 +2,7 @@ package org.folio.sidecar.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.vertx.core.http.HttpMethod;
@@ -28,6 +29,26 @@ class RoutingUtilsTest {
     var routingContext = routingContext("111111/users", null);
     var actual = RoutingUtils.getRequestId(routingContext);
     assertThat(actual).isNotNull().matches("111111/users;\\d{6}/foo");
+  }
+
+  @Test
+  void isEgressRequest_positive() {
+    var routingContext = mock(RoutingContext.class);
+    when(routingContext.get(RoutingUtils.EGRESS_REQUEST_KEY)).thenReturn(Boolean.TRUE);
+    assertThat(RoutingUtils.isEgressRequest(routingContext)).isTrue();
+  }
+
+  @Test
+  void isEgressRequest_negative_notMarked() {
+    var routingContext = mock(RoutingContext.class);
+    assertThat(RoutingUtils.isEgressRequest(routingContext)).isFalse();
+  }
+
+  @Test
+  void markAsEgressRequest_positive() {
+    var routingContext = mock(RoutingContext.class);
+    RoutingUtils.markAsEgressRequest(routingContext);
+    verify(routingContext).put(RoutingUtils.EGRESS_REQUEST_KEY, true);
   }
 
   @Test

--- a/src/test/resources/json/egress-unauthorized-error.json
+++ b/src/test/resources/json/egress-unauthorized-error.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "type": "EgressUnauthorizedException",
+      "code": "authorization_error",
+      "message": "Service Unavailable. Retry later"
+    }
+  ],
+  "total_records": 1
+}

--- a/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
+++ b/src/test/resources/mappings/am/mod-foo-0.2.1-boostrap.json
@@ -137,6 +137,11 @@
                 },
                 {
                   "methods": [ "GET" ],
+                  "pathPattern": "/bar/entities/{id}",
+                  "permissionsRequired": [ "item.get" ]
+                },
+                {
+                  "methods": [ "GET" ],
                   "pathPattern": "/bar/no-module-id-header",
                   "permissionsRequired": [ "bar.no-module-id-header.get" ]
                 }

--- a/src/test/resources/mappings/mod-bar-0.5.1.json
+++ b/src/test/resources/mappings/mod-bar-0.5.1.json
@@ -171,6 +171,32 @@
     {
       "request": {
         "method": "GET",
+        "urlPath": "/bar/entities/unauthorized",
+        "headers": {
+          "Content-Type": {
+            "equalTo": "application/json"
+          },
+          "X-Okapi-Tenant": {
+            "equalTo": "testtenant"
+          },
+          "X-System-Token": {
+            "matches": ".+"
+          }
+        }
+      },
+      "response": {
+        "status": 401,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "errors": [{"message": "Token is invalid or expired"}]
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "urlPath": "/bar/no-module-id-header",
         "headers": {
           "Content-Type": {


### PR DESCRIPTION
### **Purpose**
Invalid cache configuration or timing issues can cause module-to-module (egress) calls to fail with `401 Unauthorized`, requiring manual intervention. This change makes the sidecar self-correct by intercepting upstream 401s, invalidating the stale system token cache entry, and returning 503 with a `Retry-After` header so the original caller knows to retry.

US: [MODSIDECAR-178](https://folio-org.atlassian.net/browse/MODSIDECAR-178)

### **Approach**
When a 401 response is received from an upstream module on an egress request, `RequestForwardingService` now drains the response body, logs the interception at INFO level, and fails the request with the new `EgressUnauthorizedException`. `EgressRequestHandler` recovers from this exception by calling `ServiceTokenProvider.invalidateToken(tenant)` to evict the stale cache entry, and `ErrorHandler` maps the exception to a 503 Service Unavailable with a `Retry-After: 1` header.

**Implementation details:**

- Introduced `EgressUnauthorizedException` to distinguish upstream 401s on egress from other failures; this dedicated type lets each layer in the chain react appropriately without inspecting raw HTTP status codes.
- When a 401 is detected on an egress response, the sidecar now drains the upstream body to cleanly release the connection and logs the event at INFO before propagating the failure — making the interception observable in logs without being noisy.
- The stale system token is evicted from the cache as soon as a 401 is caught, so the very next request for that tenant will fetch a fresh token from Keycloak rather than reusing the one that was already rejected.
- The caller receives a 503 Service Unavailable with a `Retry-After: 1` header instead of a raw 401, clearly signalling a transient sidecar-level problem and telling the client when it is safe to retry.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
