### PR TITLE
feat(logging): set minimum log level for sidecar to TRACE

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # quarkus logging configuration
 quarkus.log.level=${ROOT_LOG_LEVEL:INFO}
 quarkus.log.category."org.folio.sidecar".level=${SC_LOG_LEVEL:INFO}
+quarkus.log.category."org.folio.sidecar".min-level=TRACE
 
 quarkus.http.record-request-start-time=true
 


### PR DESCRIPTION
### **Purpose**
Set minimum log level for sidecar to TRACE. This will make possible to enable tracing of sidecar's code via existing `SC_LOG_LEVEL` variable and avoid warnings like:
```
2026-05-28 11:49:25,489 WARN  [io.quarkus.runtime.logging.LoggingSetupRecorder] (main) Log level TRACE for category 'org.folio.sidecar' set below minimum logging level DEBUG, promoting it to DEBUG. Set the build time configuration property 'quarkus.log.category."org.folio.sidecar".min-level' to 'TRACE' to avoid this warning
```

