### PR TITLE
MODSIDECAR-194 Update Kafka dev services image to 4.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Changes:
 * Invalidate system token cache on egress 401 and return 503 with Retry-After header ([MODSIDECAR-178](https://folio-org.atlassian.net/browse/MODSIDECAR-178))
 * Adjust Keycloak error handling ([MODSIDECAR-192](https://folio-org.atlassian.net/browse/MODSIDECAR-192))
+* Update Kafka Dev Services image to Kafka 4.2.0 ([MODSIDECAR-194](https://folio-org.atlassian.net/browse/MODSIDECAR-194))
 
 ## Version `v4.0.0` (16.04.2026)
 ### Changes:

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.application.name=folio-module-sidecar
 quarkus.http.test-port=0
+quarkus.kafka.devservices.image-name=apache/kafka-native:4.2.0
 quarkus.log.category."io.smallrye.faulttolerance".level=DEBUG
 quarkus.log.category."service.org.folio.sidecar.ErrorHandler".level=DEBUG
 # quarkus configuration


### PR DESCRIPTION
### **Purpose**
Fix for https://folio-org.atlassian.net/browse/MODSIDECAR-194

### **Approach**

Quarkus 3.36.0 already resolves org.apache.kafka:kafka-clients:4.2.0, so no POM dependency change is needed for Kafka 4.2 compatibility. The only required change is updating the Kafka Dev Services/Testcontainers image to apache/kafka-native:4.2.0 so integration tests run against Kafka 4.2.

Vert.x 5.0.12 is not compatible with Quarkus 3.36.0. So, it is not possible to upgrade to Vert.x 5.0.12.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
