### PR TITLE
EUREKASUP-156: Multi-version module deployment – per-application egress routing

### DIFF
--- a/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerClient.java
+++ b/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerClient.java
@@ -36,9 +36,22 @@ public class ApplicationManagerClient {
    * @return {@link Future} of {@link ModuleBootstrap} object
    */
   public Future<ModuleBootstrap> getModuleBootstrap(String moduleId, String token) {
-    log.info("Loading module bootstrap: moduleId = {}", moduleId);
+    return getModuleBootstrap(moduleId, null, token);
+  }
 
-    return doGet(moduleUrl(moduleId), token)
+  /**
+   * Provides module bootstrap information from Application Manager.
+   *
+   * @param moduleId - module identifier
+   * @param applicationId - optional application identifier to scope the bootstrap lookup
+   * @param token - okapi token
+   * @return {@link Future} of {@link ModuleBootstrap} object
+   */
+  public Future<ModuleBootstrap> getModuleBootstrap(String moduleId, String applicationId, String token) {
+    log.info("Loading module bootstrap: moduleId = {}, applicationId = {}", moduleId, applicationId);
+
+    var url = moduleUrl(moduleId) + (applicationId != null ? "?applicationId=" + applicationId : "");
+    return doGet(url, token)
       .map(response -> jsonConverter.parseResponse(response, ModuleBootstrap.class))
       .onSuccess(mb -> log.debug("Module bootstrapping info loaded: {}", mb))
       .onFailure(error -> log.warn("Failed to retrieve module bootstrap: {}", error.getMessage()));

--- a/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerClient.java
+++ b/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerClient.java
@@ -10,6 +10,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.log4j.Log4j2;
 import org.folio.sidecar.integration.am.model.ModuleBootstrap;
 import org.folio.sidecar.integration.am.model.ModuleDiscovery;
@@ -50,7 +52,8 @@ public class ApplicationManagerClient {
   public Future<ModuleBootstrap> getModuleBootstrap(String moduleId, String applicationId, String token) {
     log.info("Loading module bootstrap: moduleId = {}, applicationId = {}", moduleId, applicationId);
 
-    var url = moduleUrl(moduleId) + (applicationId != null ? "?applicationId=" + applicationId : "");
+    var url = moduleUrl(moduleId)
+      + (applicationId != null ? "?applicationId=" + URLEncoder.encode(applicationId, StandardCharsets.UTF_8) : "");
     return doGet(url, token)
       .map(response -> jsonConverter.parseResponse(response, ModuleBootstrap.class))
       .onSuccess(mb -> log.debug("Module bootstrapping info loaded: {}", mb))

--- a/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerService.java
+++ b/src/main/java/org/folio/sidecar/integration/am/ApplicationManagerService.java
@@ -26,6 +26,17 @@ public class ApplicationManagerService {
     return callWithRetry(token -> client.getModuleBootstrap(moduleId, token));
   }
 
+  /**
+   * Provides module bootstrap information scoped to a specific applicationId.
+   *
+   * @param applicationId - application identifier to scope the bootstrap lookup
+   * @return {@link Future} of {@link ModuleBootstrap} object
+   */
+  public Future<ModuleBootstrap> getModuleBootstrap(String applicationId) {
+    var moduleId = moduleProperties.getId();
+    return callWithRetry(token -> client.getModuleBootstrap(moduleId, applicationId, token));
+  }
+
   public Future<ModuleDiscovery> getModuleDiscovery(String moduleId) {
     return callWithRetry(token -> client.getModuleDiscovery(moduleId, token));
   }

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
@@ -33,15 +33,18 @@ public class TenantEntitlementConsumer {
     var applicationId = event.getApplicationId();
     if (shouldEnableTenant(event.getType())) {
       tenantService.enableTenant(tenantName, applicationId);
-      applicationManagerService.getModuleBootstrap(applicationId)
-        .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
-          bootstrap.getRequiredModules()))
-        .onFailure(err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
+      if (applicationId != null) {
+        applicationManagerService.getModuleBootstrap(applicationId)
+          .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
+            bootstrap.getRequiredModules()))
+          .onFailure(
+            err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
+      }
       return;
     }
 
     tenantService.disableTenant(tenantName, applicationId);
-    if (tenantService.getAllApplicationIds().stream().noneMatch(applicationId::equals)) {
+    if (applicationId != null && tenantService.getAllApplicationIds().stream().noneMatch(applicationId::equals)) {
       egressRoutingLookup.onApplicationRevoked(applicationId);
     }
   }

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
@@ -26,12 +26,13 @@ public class TenantEntitlementConsumer {
     }
 
     var tenantName = event.getTenantName();
+    var applicationId = event.getApplicationId();
     if (shouldEnableTenant(event.getType())) {
-      tenantService.enableTenant(tenantName);
+      tenantService.enableTenant(tenantName, applicationId);
       return;
     }
 
-    tenantService.disableTenant(tenantName);
+    tenantService.disableTenant(tenantName, applicationId);
   }
 
   private boolean shouldEnableTenant(Type type) {

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
@@ -43,14 +43,17 @@ public class TenantEntitlementConsumer {
   }
 
   private void handleEnableTenant(String tenantName, String applicationId) {
-    tenantService.enableTenant(tenantName, applicationId);
-    if (applicationId != null) {
-      applicationManagerService.getModuleBootstrap(applicationId)
-        .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
-          bootstrap.getRequiredModules()))
-        .onFailure(
-          err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
+    if (applicationId == null) {
+      tenantService.enableTenant(tenantName, null);
+      return;
     }
+    applicationManagerService.getModuleBootstrap(applicationId)
+      .onSuccess(bootstrap -> {
+        tenantService.enableTenant(tenantName, applicationId);
+        egressRoutingLookup.onApplicationBootstrap(applicationId, bootstrap.getRequiredModules());
+      })
+      .onFailure(err -> log.warn("Failed to load bootstrap for application {}, tenant not enabled: {} {}",
+        applicationId, tenantName, err.getMessage()));
   }
 
   private boolean shouldEnableTenant(Type type) {

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
@@ -7,8 +7,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.folio.sidecar.integration.am.ApplicationManagerService;
 import org.folio.sidecar.integration.kafka.TenantEntitlementEvent.Type;
 import org.folio.sidecar.service.TenantService;
+import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
 
 @Log4j2
 @ApplicationScoped
@@ -16,6 +18,8 @@ import org.folio.sidecar.service.TenantService;
 public class TenantEntitlementConsumer {
 
   private final TenantService tenantService;
+  private final ApplicationManagerService applicationManagerService;
+  private final EgressRoutingLookup egressRoutingLookup;
 
   @Incoming("entitlement")
   public void consume(TenantEntitlementEvent event) {
@@ -29,10 +33,17 @@ public class TenantEntitlementConsumer {
     var applicationId = event.getApplicationId();
     if (shouldEnableTenant(event.getType())) {
       tenantService.enableTenant(tenantName, applicationId);
+      applicationManagerService.getModuleBootstrap(applicationId)
+        .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
+          bootstrap.getRequiredModules()))
+        .onFailure(err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
       return;
     }
 
     tenantService.disableTenant(tenantName, applicationId);
+    if (tenantService.getAllApplicationIds().stream().noneMatch(applicationId::equals)) {
+      egressRoutingLookup.onApplicationRevoked(applicationId);
+    }
   }
 
   private boolean shouldEnableTenant(Type type) {

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementConsumer.java
@@ -32,20 +32,24 @@ public class TenantEntitlementConsumer {
     var tenantName = event.getTenantName();
     var applicationId = event.getApplicationId();
     if (shouldEnableTenant(event.getType())) {
-      tenantService.enableTenant(tenantName, applicationId);
-      if (applicationId != null) {
-        applicationManagerService.getModuleBootstrap(applicationId)
-          .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
-            bootstrap.getRequiredModules()))
-          .onFailure(
-            err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
-      }
+      handleEnableTenant(tenantName, applicationId);
       return;
     }
 
     tenantService.disableTenant(tenantName, applicationId);
     if (applicationId != null && tenantService.getAllApplicationIds().stream().noneMatch(applicationId::equals)) {
       egressRoutingLookup.onApplicationRevoked(applicationId);
+    }
+  }
+
+  private void handleEnableTenant(String tenantName, String applicationId) {
+    tenantService.enableTenant(tenantName, applicationId);
+    if (applicationId != null) {
+      applicationManagerService.getModuleBootstrap(applicationId)
+        .onSuccess(bootstrap -> egressRoutingLookup.onApplicationBootstrap(applicationId,
+          bootstrap.getRequiredModules()))
+        .onFailure(
+          err -> log.warn("Failed to load bootstrap for application {}: {}", applicationId, err.getMessage()));
     }
   }
 

--- a/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementEvent.java
+++ b/src/main/java/org/folio/sidecar/integration/kafka/TenantEntitlementEvent.java
@@ -1,5 +1,6 @@
 package org.folio.sidecar.integration.kafka;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.UUID;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
 @RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TenantEntitlementEvent {
 
   /**
@@ -36,6 +38,12 @@ public class TenantEntitlementEvent {
    */
   @JsonProperty("type")
   private Type type;
+
+  /**
+   * An application identifier.
+   */
+  @JsonProperty("applicationId")
+  private String applicationId;
 
   public enum Type {
     ENTITLE,

--- a/src/main/java/org/folio/sidecar/service/TenantService.java
+++ b/src/main/java/org/folio/sidecar/service/TenantService.java
@@ -70,8 +70,13 @@ public class TenantService {
   /**
    * Enables a tenant for the given applicationId.
    * A tenant remains enabled as long as at least one applicationId is registered for it.
+   * When applicationId is null (legacy events without applicationId) the call is a no-op.
    */
   public void enableTenant(String tenantName, String applicationId) {
+    if (applicationId == null) {
+      log.warn("enableTenant called with null applicationId for tenant: {}; ignoring", tenantName);
+      return;
+    }
     var apps = tenantApplications.computeIfAbsent(tenantName, k -> ConcurrentHashMap.newKeySet());
     if (apps.add(applicationId)) {
       log.info("Enabling tenant: {} for application: {}", tenantName, applicationId);
@@ -82,8 +87,13 @@ public class TenantService {
   /**
    * Disables a tenant for the given applicationId.
    * If the tenant has no more registered applicationIds it is fully disabled.
+   * When applicationId is null (legacy events without applicationId) the call is a no-op.
    */
   public void disableTenant(String tenantName, String applicationId) {
+    if (applicationId == null) {
+      log.warn("disableTenant called with null applicationId for tenant: {}; ignoring", tenantName);
+      return;
+    }
     var apps = tenantApplications.get(tenantName);
     if (apps == null) {
       return;
@@ -102,6 +112,9 @@ public class TenantService {
    * Returns the set of applicationIds registered for the given tenant.
    */
   public Set<String> getApplicationIds(String tenantName) {
+    if (tenantName == null) {
+      return Collections.emptySet();
+    }
     var apps = tenantApplications.get(tenantName);
     return apps == null ? Collections.emptySet() : Set.copyOf(apps);
   }

--- a/src/main/java/org/folio/sidecar/service/TenantService.java
+++ b/src/main/java/org/folio/sidecar/service/TenantService.java
@@ -6,13 +6,16 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import io.quarkus.scheduler.Scheduled;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -39,7 +42,13 @@ public class TenantService {
   private final TenantEntitlementClient tenantEntitlementClient;
   private final ModuleProperties moduleProperties;
   private final EventBus eventBus;
-  private final Set<String> enabledTenants = new ConcurrentHashSet<>();
+
+  /**
+   * Maps tenant name → set of applicationIds that have entitled this tenant.
+   * A tenant is considered enabled if and only if its set is non-empty.
+   */
+  private final Map<String, Set<String>> tenantApplications = new ConcurrentHashMap<>();
+
   private final AtomicBoolean canExecuteTenantsAndEntitlementsTask = new AtomicBoolean(false);
 
   private Promise<Void> initPromise = Promise.promise();
@@ -58,18 +67,52 @@ public class TenantService {
     return result;
   }
 
-  public void enableTenant(String tenantName) {
-    if (enabledTenants.add(tenantName)) {
-      log.info("Enabling tenant: {}", tenantName);
+  /**
+   * Enables a tenant for the given applicationId.
+   * A tenant remains enabled as long as at least one applicationId is registered for it.
+   */
+  public void enableTenant(String tenantName, String applicationId) {
+    var apps = tenantApplications.computeIfAbsent(tenantName, k -> ConcurrentHashMap.newKeySet());
+    if (apps.add(applicationId)) {
+      log.info("Enabling tenant: {} for application: {}", tenantName, applicationId);
       notifyEntitlementsChanged();
     }
   }
 
-  public void disableTenant(String tenantName) {
-    if (enabledTenants.remove(tenantName)) {
-      log.info("Disabling tenant: {}", tenantName);
+  /**
+   * Disables a tenant for the given applicationId.
+   * If the tenant has no more registered applicationIds it is fully disabled.
+   */
+  public void disableTenant(String tenantName, String applicationId) {
+    var apps = tenantApplications.get(tenantName);
+    if (apps == null) {
+      return;
+    }
+    if (apps.remove(applicationId)) {
+      log.info("Disabling tenant: {} for application: {}", tenantName, applicationId);
+      if (apps.isEmpty()) {
+        tenantApplications.remove(tenantName);
+        log.info("Tenant {} fully disabled (no more applications)", tenantName);
+      }
       notifyEntitlementsChanged();
     }
+  }
+
+  /**
+   * Returns the set of applicationIds registered for the given tenant.
+   */
+  public Set<String> getApplicationIds(String tenantName) {
+    var apps = tenantApplications.get(tenantName);
+    return apps == null ? Collections.emptySet() : Set.copyOf(apps);
+  }
+
+  /**
+   * Returns all applicationIds across all enabled tenants.
+   */
+  public Set<String> getAllApplicationIds() {
+    return tenantApplications.values().stream()
+      .flatMap(Set::stream)
+      .collect(Collectors.toUnmodifiableSet());
   }
 
   public boolean isAssignedModule(String moduleId) {
@@ -77,13 +120,13 @@ public class TenantService {
   }
 
   public Future<Set<String>> getEnabledTenants() {
-    return loadingFuture.map(v -> Set.copyOf(enabledTenants));
+    return loadingFuture.map(v -> Set.copyOf(tenantApplications.keySet()));
   }
 
   public Future<Boolean> isEnabledTenant(String name) {
     return isEmpty(name)
       ? succeededFuture(false)
-      : loadingFuture.map(v -> enabledTenants.contains(name));
+      : loadingFuture.map(v -> tenantApplications.containsKey(name));
   }
 
   /**
@@ -113,30 +156,38 @@ public class TenantService {
     var retryFuture = retryTemplate.callAsync(() ->
       tokenProvider.getAdminToken().compose(token ->
         tenantEntitlementClient.getModuleEntitlements(moduleProperties.getId(), token)
-          .map(TenantService::getTenantIds)
-          .compose(tenantIds -> tenantManagerClient.getTenantInfo(tenantIds, token)
-            .onSuccess(this::addEnabledTenants)
-            .onFailure(throwable -> log.warn("Failed to load tenants", throwable)))
+          .compose(entitlements -> {
+            var tenantIdToAppId = buildTenantIdToAppIdMap(entitlements);
+            var tenantIds = List.copyOf(tenantIdToAppId.keySet());
+            return tenantManagerClient.getTenantInfo(tenantIds, token)
+              .onSuccess(tenants -> addEnabledTenants(tenants, tenantIdToAppId))
+              .onFailure(throwable -> log.warn("Failed to load tenants", throwable));
+          })
           .onFailure(throwable -> log.warn("Failed to load tenant entitlements", throwable)))
     );
 
     retryFuture.onComplete(unused -> promise.complete(), promise::fail);
   }
 
-  private void addEnabledTenants(List<Tenant> tenants) {
-    enabledTenants.clear();
-    tenants.forEach(tenant -> enabledTenants.add(tenant.getName()));
+  private void addEnabledTenants(List<Tenant> tenants, Map<String, String> tenantIdToAppId) {
+    tenantApplications.clear();
+    for (var tenant : tenants) {
+      var appId = tenantIdToAppId.get(tenant.getId().toString());
+      if (appId != null) {
+        tenantApplications.computeIfAbsent(tenant.getName(), k -> ConcurrentHashMap.newKeySet()).add(appId);
+      }
+    }
     log.info("Module is enabled for tenants: {}", () -> tenants.stream().map(Tenant::getName).toList());
     notifyEntitlementsChanged();
   }
 
   private void notifyEntitlementsChanged() {
-    eventBus.publish(EntitlementsEvent.ENTITLEMENTS_EVENT, EntitlementsEvent.of(Set.copyOf(enabledTenants)));
+    eventBus.publish(EntitlementsEvent.ENTITLEMENTS_EVENT,
+      EntitlementsEvent.of(Set.copyOf(tenantApplications.keySet())));
   }
 
-  private static List<String> getTenantIds(ResultList<Entitlement> resultList) {
-    return resultList.getRecords()
-      .stream().map(Entitlement::getTenantId)
-      .toList();
+  private static Map<String, String> buildTenantIdToAppIdMap(ResultList<Entitlement> resultList) {
+    return resultList.getRecords().stream()
+      .collect(Collectors.toMap(Entitlement::getTenantId, Entitlement::getApplicationId, (a, b) -> a));
   }
 }

--- a/src/main/java/org/folio/sidecar/service/TenantService.java
+++ b/src/main/java/org/folio/sidecar/service/TenantService.java
@@ -182,12 +182,13 @@ public class TenantService {
     retryFuture.onComplete(unused -> promise.complete(), promise::fail);
   }
 
-  private void addEnabledTenants(List<Tenant> tenants, Map<String, String> tenantIdToAppId) {
+  private void addEnabledTenants(List<Tenant> tenants, Map<String, Set<String>> tenantIdToAppIds) {
     tenantApplications.clear();
     for (var tenant : tenants) {
-      var appId = tenantIdToAppId.get(tenant.getId().toString());
-      if (appId != null) {
-        tenantApplications.computeIfAbsent(tenant.getName(), k -> ConcurrentHashMap.newKeySet()).add(appId);
+      var appIds = tenantIdToAppIds.get(tenant.getId().toString());
+      if (appIds != null && !appIds.isEmpty()) {
+        var apps = tenantApplications.computeIfAbsent(tenant.getName(), k -> ConcurrentHashMap.newKeySet());
+        apps.addAll(appIds);
       }
     }
     log.info("Module is enabled for tenants: {}", () -> tenants.stream().map(Tenant::getName).toList());
@@ -199,8 +200,9 @@ public class TenantService {
       EntitlementsEvent.of(Set.copyOf(tenantApplications.keySet())));
   }
 
-  private static Map<String, String> buildTenantIdToAppIdMap(ResultList<Entitlement> resultList) {
+  private static Map<String, Set<String>> buildTenantIdToAppIdMap(ResultList<Entitlement> resultList) {
     return resultList.getRecords().stream()
-      .collect(Collectors.toMap(Entitlement::getTenantId, Entitlement::getApplicationId, (a, b) -> a));
+      .collect(Collectors.groupingBy(Entitlement::getTenantId,
+        Collectors.mapping(Entitlement::getApplicationId, Collectors.toSet())));
   }
 }

--- a/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
@@ -15,6 +15,7 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ import org.folio.sidecar.service.ModulePermissionsService;
 import org.folio.sidecar.service.TenantService;
 import org.folio.sidecar.service.routing.configuration.RequestHandler;
 import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
+import org.folio.sidecar.utils.GenericCompositeFuture;
 
 @Log4j2
 @ApplicationScoped
@@ -57,10 +59,7 @@ public class RoutingService implements DiscoveryListener {
   }
 
   public Future<Void> init(Router router) {
-    return loadBootstrapAndProcess(moduleBootstrap -> {
-      initFromBootstrap(router, moduleBootstrap);
-      loadEgressBootstrapPerApplication();
-    });
+    return loadBootstrapAndProcess(moduleBootstrap -> initFromBootstrap(router, moduleBootstrap));
   }
 
   @Override
@@ -76,25 +75,43 @@ public class RoutingService implements DiscoveryListener {
     }
   }
 
-  private void loadEgressBootstrapPerApplication() {
+  /**
+   * Loads per-application egress bootstrap for every applicationId currently known to {@link TenantService}.
+   *
+   * <p>Must be called after {@link TenantService#init()} has populated tenant→application mappings;
+   * otherwise the iteration sees an empty set and no per-application caches are built.
+   *
+   * <p>Per-application failures are logged and swallowed so a single failing application does not block
+   * the others; the returned future always succeeds.
+   */
+  public Future<Void> loadEgressBootstrapPerApplication() {
     var applicationIds = tenantService.getAllApplicationIds();
-    for (var applicationId : applicationIds) {
-      appManagerService.getModuleBootstrap(applicationId)
-        .onSuccess(bootstrap -> egressLookup.onApplicationBootstrap(applicationId, bootstrap.getRequiredModules()))
-        .onFailure(error -> log.warn("Failed to load egress bootstrap for application: {}", applicationId, error));
+    if (applicationIds.isEmpty()) {
+      return Future.succeededFuture();
     }
+    var futures = new ArrayList<Future<Void>>(applicationIds.size());
+    for (var applicationId : applicationIds) {
+      Future<Void> f = appManagerService.getModuleBootstrap(applicationId)
+        .onSuccess(bootstrap -> egressLookup.onApplicationBootstrap(applicationId, bootstrap.getRequiredModules()))
+        .onFailure(error -> log.warn("Failed to load egress bootstrap for application: {}", applicationId, error))
+        .recover(error -> Future.succeededFuture(null))
+        .mapEmpty();
+      futures.add(f);
+    }
+    return GenericCompositeFuture.join(futures).mapEmpty();
   }
 
   private Future<Void> loadBootstrapAndProcess(Consumer<ModuleBootstrap> consumer) {
     return appManagerService.getModuleBootstrap()
       .map(moduleBootstrap -> {
         consumer.accept(moduleBootstrap);
-        return (Void) null;
+        return null;
       })
       .onFailure(error -> {
         log.error("Failed to initialize routes", error);
         Quarkus.asyncExit(0);
-      });
+      })
+      .mapEmpty();
   }
 
   private void initFromBootstrap(Router router, ModuleBootstrap moduleBootstrap) {

--- a/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
+++ b/src/main/java/org/folio/sidecar/service/routing/RoutingService.java
@@ -24,7 +24,9 @@ import org.folio.sidecar.integration.am.ApplicationManagerService;
 import org.folio.sidecar.integration.am.model.ModuleBootstrap;
 import org.folio.sidecar.integration.kafka.DiscoveryListener;
 import org.folio.sidecar.service.ModulePermissionsService;
+import org.folio.sidecar.service.TenantService;
 import org.folio.sidecar.service.routing.configuration.RequestHandler;
+import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
 
 @Log4j2
 @ApplicationScoped
@@ -35,10 +37,12 @@ public class RoutingService implements DiscoveryListener {
   private final List<ModuleBootstrapListener> moduleBootstrapListeners;
   private final Map<String, ModuleType> knownModules = new HashMap<>();
   private final ModulePermissionsService modulePermissionsService;
+  private final TenantService tenantService;
+  private final EgressRoutingLookup egressLookup;
 
   public RoutingService(ApplicationManagerService appManagerService,
     @RequestHandler @All List<Handler<RoutingContext>> requestHandlers, @All List<ModuleBootstrapListener> mbListeners,
-    ModulePermissionsService modulePermissionsService) {
+    ModulePermissionsService modulePermissionsService, TenantService tenantService, EgressRoutingLookup egressLookup) {
     this.appManagerService = appManagerService;
 
     if (isEmpty(requestHandlers)) {
@@ -48,10 +52,15 @@ public class RoutingService implements DiscoveryListener {
 
     this.moduleBootstrapListeners = mbListeners;
     this.modulePermissionsService = modulePermissionsService;
+    this.tenantService = tenantService;
+    this.egressLookup = egressLookup;
   }
 
   public Future<Void> init(Router router) {
-    return loadBootstrapAndProcess(moduleBootstrap -> initFromBootstrap(router, moduleBootstrap));
+    return loadBootstrapAndProcess(moduleBootstrap -> {
+      initFromBootstrap(router, moduleBootstrap);
+      loadEgressBootstrapPerApplication();
+    });
   }
 
   @Override
@@ -64,6 +73,15 @@ public class RoutingService implements DiscoveryListener {
 
     if (type != null) {
       loadBootstrapAndProcess(updateModuleRoutesByType(type, moduleId));
+    }
+  }
+
+  private void loadEgressBootstrapPerApplication() {
+    var applicationIds = tenantService.getAllApplicationIds();
+    for (var applicationId : applicationIds) {
+      appManagerService.getModuleBootstrap(applicationId)
+        .onSuccess(bootstrap -> egressLookup.onApplicationBootstrap(applicationId, bootstrap.getRequiredModules()))
+        .onFailure(error -> log.warn("Failed to load egress bootstrap for application: {}", applicationId, error));
     }
   }
 

--- a/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
+++ b/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
@@ -8,6 +8,7 @@ import static org.folio.sidecar.service.routing.lookup.RoutingLookupUtils.lookup
 import static org.folio.sidecar.utils.RoutingUtils.dumpUri;
 
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
@@ -16,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -45,28 +47,28 @@ public class EgressRoutingLookup implements RoutingLookup, ModuleBootstrapListen
 
     var tenant = request.getHeader(OkapiHeaders.TENANT);
     var applicationIds = tenantService.getApplicationIds(tenant);
+    var entry = findEntryInApplicationCaches(path, request, applicationIds);
 
-    Optional<ScRoutingEntry> entry = Optional.empty();
-    String selectedAppId = null;
+    if (entry.isEmpty()) {
+      log.debug("Egress entry found: {}", entry);
+    }
+    return succeededFuture(entry);
+  }
+
+  private Optional<ScRoutingEntry> findEntryInApplicationCaches(String path,
+    HttpServerRequest request, Set<String> applicationIds) {
     for (var appId : applicationIds) {
       var appCache = cachePerApplication.get(appId);
       if (appCache != null) {
-        entry = lookup(request, path, appCache, true);
+        var entry = lookup(request, path, appCache, true);
         if (entry.isPresent()) {
-          selectedAppId = appId;
-          break;
+          log.debug("Egress route selected: applicationId={} interface={} module={} -> {}",
+            appId, entry.get().getInterfaceId(), entry.get().getModuleId(), entry.get().getLocation());
+          return entry;
         }
       }
     }
-
-    if (entry.isPresent()) {
-      log.debug("Egress route selected: applicationId={} interface={} module={} -> {}",
-          selectedAppId, entry.get().getInterfaceId(), entry.get().getModuleId(), entry.get().getLocation());
-    } else {
-      log.debug("Egress entry found: {}", entry);
-    }
-
-    return succeededFuture(entry);
+    return Optional.empty();
   }
 
   /**

--- a/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
+++ b/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
@@ -11,42 +11,103 @@ import io.vertx.core.Future;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.sidecar.integration.am.model.ModuleBootstrapDiscovery;
+import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.sidecar.model.ScRoutingEntry;
+import org.folio.sidecar.service.TenantService;
 import org.folio.sidecar.service.routing.ModuleBootstrapListener;
 
 @Log4j2
 @Named("egressLookup")
 @ApplicationScoped
+@RequiredArgsConstructor
 public class EgressRoutingLookup implements RoutingLookup, ModuleBootstrapListener {
 
-  private Map<String, List<ScRoutingEntry>> egressRequestCache = new HashMap<>();
+  /**
+   * Per-application routing cache: applicationId → (pathPrefix → list of routing entries).
+   */
+  private final Map<String, Map<String, List<ScRoutingEntry>>> cachePerApplication = new ConcurrentHashMap<>();
+
+  private final TenantService tenantService;
 
   @Override
   public Future<Optional<ScRoutingEntry>> lookupRoute(String path, RoutingContext rc) {
     var request = rc.request();
     log.debug("Searching routing entries for egress request: method [{}], uri [{}]", request::method, dumpUri(rc));
 
-    var entry = lookup(request, path, egressRequestCache, true);
+    var tenant = request.getHeader(OkapiHeaders.TENANT);
+    var applicationIds = tenantService.getApplicationIds(tenant);
+
+    Optional<ScRoutingEntry> entry = Optional.empty();
+    for (var appId : applicationIds) {
+      var appCache = cachePerApplication.get(appId);
+      if (appCache != null) {
+        entry = lookup(request, path, appCache, true);
+        if (entry.isPresent()) {
+          break;
+        }
+      }
+    }
 
     log.debug("Egress entry found: {}", entry);
 
     return succeededFuture(entry);
   }
 
+  /**
+   * Populates (or replaces) the routing cache for the given applicationId.
+   *
+   * @param applicationId the application whose modules are being bootstrapped
+   * @param modules       list of required-module discovery entries for that application
+   */
+  public void onApplicationBootstrap(String applicationId, List<ModuleBootstrapDiscovery> modules) {
+    log.info("Initializing egress routes for application: {}", applicationId);
+
+    var routes = getCollectedRoutes(modules);
+    cachePerApplication.put(applicationId, routes);
+
+    log.info("Egress routes initialized for application {}: count = {}", applicationId, calculateRoutes(routes));
+  }
+
+  /**
+   * Removes the routing cache entry for the given applicationId (e.g. after revocation).
+   *
+   * @param applicationId the application being revoked
+   */
+  public void onApplicationRevoked(String applicationId) {
+    log.info("Removing egress routes for revoked application: {}", applicationId);
+    cachePerApplication.remove(applicationId);
+  }
+
+  /**
+   * Backward-compatible entry point: distributes required modules into per-application caches grouped by
+   * {@code applicationId}.  Called from {@link org.folio.sidecar.service.routing.RoutingService} during startup and
+   * on discovery updates until Task 3.6 migrates the call site to {@link #onApplicationBootstrap}.
+   *
+   * @param requiredModulesBootstrap list of required-module discovery entries (may span multiple applications)
+   * @param changeType               INIT or UPDATE (informational only)
+   */
   @Override
   public void onRequiredModulesBootstrap(List<ModuleBootstrapDiscovery> requiredModulesBootstrap,
     ChangeType changeType) {
     log.info("{} module egress routes", changeType == INIT ? "Initializing" : "Updating");
 
-    egressRequestCache = getCollectedRoutes(requiredModulesBootstrap);
+    if (requiredModulesBootstrap == null || requiredModulesBootstrap.isEmpty()) {
+      return;
+    }
 
-    log.info("Egress routes {}: count = {}", () -> changeType == INIT ? "initialized" : "updated",
-      () -> calculateRoutes(egressRequestCache));
+    var byApp = new HashMap<String, List<ModuleBootstrapDiscovery>>();
+    for (var module : requiredModulesBootstrap) {
+      byApp.computeIfAbsent(module.getApplicationId(), k -> new ArrayList<>()).add(module);
+    }
+    byApp.forEach(this::onApplicationBootstrap);
   }
 }

--- a/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
+++ b/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
@@ -50,14 +50,15 @@ public class EgressRoutingLookup implements RoutingLookup, ModuleBootstrapListen
     var entry = findEntryInApplicationCaches(path, request, applicationIds);
 
     if (entry.isEmpty()) {
-      log.debug("Egress entry found: {}", entry);
+      log.debug("No egress entry found for path [{}]", path);
     }
     return succeededFuture(entry);
   }
 
   private Optional<ScRoutingEntry> findEntryInApplicationCaches(String path,
     HttpServerRequest request, Set<String> applicationIds) {
-    for (var appId : applicationIds) {
+    // Sorted for deterministic selection when tenant has multiple apps with overlapping routes
+    for (var appId : applicationIds.stream().sorted().toList()) {
       var appCache = cachePerApplication.get(appId);
       if (appCache != null) {
         var entry = lookup(request, path, appCache, true);

--- a/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
+++ b/src/main/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookup.java
@@ -47,17 +47,24 @@ public class EgressRoutingLookup implements RoutingLookup, ModuleBootstrapListen
     var applicationIds = tenantService.getApplicationIds(tenant);
 
     Optional<ScRoutingEntry> entry = Optional.empty();
+    String selectedAppId = null;
     for (var appId : applicationIds) {
       var appCache = cachePerApplication.get(appId);
       if (appCache != null) {
         entry = lookup(request, path, appCache, true);
         if (entry.isPresent()) {
+          selectedAppId = appId;
           break;
         }
       }
     }
 
-    log.debug("Egress entry found: {}", entry);
+    if (entry.isPresent()) {
+      log.debug("Egress route selected: applicationId={} interface={} module={} -> {}",
+          selectedAppId, entry.get().getInterfaceId(), entry.get().getModuleId(), entry.get().getLocation());
+    } else {
+      log.debug("Egress entry found: {}", entry);
+    }
 
     return succeededFuture(entry);
   }

--- a/src/main/java/org/folio/sidecar/startup/SidecarInitializer.java
+++ b/src/main/java/org/folio/sidecar/startup/SidecarInitializer.java
@@ -30,8 +30,10 @@ public class SidecarInitializer {
 
     // chain of initialization:
     // 1. routing service and everything that depends on it
-    // 2. tenant service
+    // 2. tenant service (populates tenant→application mappings)
+    // 3. egress bootstrap per application (requires tenant→app map to be populated)
     routingService.init(router)
-      .compose(unused -> tenantService.init());
+      .compose(unused -> tenantService.init())
+      .compose(unused -> routingService.loadEgressBootstrapPerApplication());
   }
 }

--- a/src/test/java/org/folio/sidecar/configuration/SidecarInitializerTest.java
+++ b/src/test/java/org/folio/sidecar/configuration/SidecarInitializerTest.java
@@ -39,6 +39,7 @@ class SidecarInitializerTest {
     when(sidecarProperties.getName()).thenReturn("sc-mod-foo");
     when(routingService.init(router)).thenReturn(succeededFuture());
     when(tenantService.init()).thenReturn(succeededFuture());
+    when(routingService.loadEgressBootstrapPerApplication()).thenReturn(succeededFuture());
 
     var initOrder = inOrder(routingService, tenantService);
 
@@ -46,5 +47,6 @@ class SidecarInitializerTest {
 
     initOrder.verify(routingService).init(router);
     initOrder.verify(tenantService).init();
+    initOrder.verify(routingService).loadEgressBootstrapPerApplication();
   }
 }

--- a/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerClientTest.java
+++ b/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerClientTest.java
@@ -98,6 +98,21 @@ class ApplicationManagerClientTest {
   }
 
   @Test
+  void getModuleBootstrap_withApplicationId_encodesSpecialChars() {
+    when(webClient.getAbs(uriCaptor.capture())).thenReturn(request);
+    when(request.putHeader(anyString(), anyString())).thenReturn(request);
+    when(request.send()).thenReturn(Future.succeededFuture(response));
+    when(response.statusCode()).thenReturn(HttpStatus.SC_OK);
+    when(response.bodyAsString()).thenReturn(readString("json/module-bootstrap.json"));
+
+    var actual = appManagerClient.getModuleBootstrap(MODULE_ID, "app id with spaces+special", AUTH_TOKEN);
+
+    assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
+    assertThat(uriCaptor.getValue())
+      .isEqualTo("http://am:8081/modules/mod-foo-0.2.1?applicationId=app+id+with+spaces%2Bspecial");
+  }
+
+  @Test
   void getModuleBootstrap_withNullApplicationId_noQueryParam() {
     when(webClient.getAbs(uriCaptor.capture())).thenReturn(request);
     when(request.putHeader(anyString(), anyString())).thenReturn(request);

--- a/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerClientTest.java
+++ b/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerClientTest.java
@@ -5,6 +5,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.sidecar.integration.okapi.OkapiHeaders.TOKEN;
 import static org.folio.sidecar.support.TestConstants.AM_PROPERTIES;
+import static org.folio.sidecar.support.TestConstants.APPLICATION_ID;
 import static org.folio.sidecar.support.TestConstants.AUTH_TOKEN;
 import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
@@ -68,6 +69,43 @@ class ApplicationManagerClientTest {
     when(response.bodyAsString()).thenReturn(readString("json/module-bootstrap.json"));
 
     var actual = appManagerClient.getModuleBootstrap(MODULE_ID, AUTH_TOKEN);
+
+    assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
+
+    verify(request).putHeader(CONTENT_TYPE, APPLICATION_JSON);
+    verify(request).putHeader(eq(TOKEN), anyString());
+    assertThat(uriCaptor.getValue()).isEqualTo("http://am:8081/modules/mod-foo-0.2.1");
+    verify(jsonConverter).parseResponse(response, ModuleBootstrap.class);
+  }
+
+  @Test
+  void getModuleBootstrap_withApplicationId_appendsQueryParam() {
+    when(webClient.getAbs(uriCaptor.capture())).thenReturn(request);
+    when(request.putHeader(anyString(), anyString())).thenReturn(request);
+    when(request.send()).thenReturn(Future.succeededFuture(response));
+    when(response.statusCode()).thenReturn(HttpStatus.SC_OK);
+    when(response.bodyAsString()).thenReturn(readString("json/module-bootstrap.json"));
+
+    var actual = appManagerClient.getModuleBootstrap(MODULE_ID, APPLICATION_ID, AUTH_TOKEN);
+
+    assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
+
+    verify(request).putHeader(CONTENT_TYPE, APPLICATION_JSON);
+    verify(request).putHeader(eq(TOKEN), anyString());
+    assertThat(uriCaptor.getValue())
+      .isEqualTo("http://am:8081/modules/mod-foo-0.2.1?applicationId=" + APPLICATION_ID);
+    verify(jsonConverter).parseResponse(response, ModuleBootstrap.class);
+  }
+
+  @Test
+  void getModuleBootstrap_withNullApplicationId_noQueryParam() {
+    when(webClient.getAbs(uriCaptor.capture())).thenReturn(request);
+    when(request.putHeader(anyString(), anyString())).thenReturn(request);
+    when(request.send()).thenReturn(Future.succeededFuture(response));
+    when(response.statusCode()).thenReturn(HttpStatus.SC_OK);
+    when(response.bodyAsString()).thenReturn(readString("json/module-bootstrap.json"));
+
+    var actual = appManagerClient.getModuleBootstrap(MODULE_ID, null, AUTH_TOKEN);
 
     assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
 

--- a/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerServiceTest.java
+++ b/src/test/java/org/folio/sidecar/integration/am/ApplicationManagerServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.sidecar.integration.am;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.sidecar.support.TestConstants.APPLICATION_ID;
 import static org.folio.sidecar.support.TestConstants.AUTH_TOKEN;
 import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
@@ -47,6 +48,17 @@ class ApplicationManagerServiceTest {
     when(appManagerClient.getModuleBootstrap(MODULE_ID, AUTH_TOKEN)).thenReturn(succeededFuture(MODULE_BOOTSTRAP));
 
     var actual = service.getModuleBootstrap();
+
+    assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
+  }
+
+  @Test
+  void getModuleBootstrap_withApplicationId_positive() {
+    when(tokenProvider.getAdminToken()).thenReturn(succeededFuture(AUTH_TOKEN));
+    when(appManagerClient.getModuleBootstrap(MODULE_ID, APPLICATION_ID, AUTH_TOKEN))
+      .thenReturn(succeededFuture(MODULE_BOOTSTRAP));
+
+    var actual = service.getModuleBootstrap(APPLICATION_ID);
 
     assertThat(actual.result()).isEqualTo(MODULE_BOOTSTRAP);
   }

--- a/src/test/java/org/folio/sidecar/integration/kafka/TenantEntitlementEventTest.java
+++ b/src/test/java/org/folio/sidecar/integration/kafka/TenantEntitlementEventTest.java
@@ -1,0 +1,45 @@
+package org.folio.sidecar.integration.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.folio.sidecar.support.TestUtils;
+import org.folio.support.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class TenantEntitlementEventTest {
+
+  @Test
+  void deserialize_extractsApplicationId() throws Exception {
+    var json = """
+      {"type":"ENTITLE","moduleId":"mod-users-19.5.4","tenantName":"diku2",
+       "tenantId":"00000000-0000-0000-0000-000000000001",
+       "applicationId":"app-platform-minimal-2.0.53"}""";
+    var event = TestUtils.OBJECT_MAPPER.readValue(json, TenantEntitlementEvent.class);
+    assertThat(event.getApplicationId()).isEqualTo("app-platform-minimal-2.0.53");
+  }
+
+  @Test
+  void deserialize_applicationIdAbsent_yieldsNull() throws Exception {
+    var json = """
+      {"type":"REVOKE","moduleId":"mod-users-19.5.4","tenantName":"diku",
+       "tenantId":"00000000-0000-0000-0000-000000000002"}""";
+    var event = TestUtils.OBJECT_MAPPER.readValue(json, TenantEntitlementEvent.class);
+    assertThat(event.getApplicationId()).isNull();
+  }
+
+  @Test
+  void deserialize_populatesOtherFields() throws Exception {
+    var json = """
+      {"type":"UPGRADE","moduleId":"mod-foo-1.0.0","tenantName":"test",
+       "tenantId":"00000000-0000-0000-0000-000000000003",
+       "applicationId":"app-test-1.0.0"}""";
+    var event = TestUtils.OBJECT_MAPPER.readValue(json, TenantEntitlementEvent.class);
+    assertThat(event.getType()).isEqualTo(TenantEntitlementEvent.Type.UPGRADE);
+    assertThat(event.getModuleId()).isEqualTo("mod-foo-1.0.0");
+    assertThat(event.getTenantName()).isEqualTo("test");
+    assertThat(event.getTenantId()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000003"));
+    assertThat(event.getApplicationId()).isEqualTo("app-test-1.0.0");
+  }
+}

--- a/src/test/java/org/folio/sidecar/it/EgressIsolationIT.java
+++ b/src/test/java/org/folio/sidecar/it/EgressIsolationIT.java
@@ -1,0 +1,189 @@
+package org.folio.sidecar.it;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import java.util.List;
+import java.util.Set;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapDiscovery;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapEndpoint;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapInterface;
+import org.folio.sidecar.integration.okapi.OkapiHeaders;
+import org.folio.sidecar.service.TenantService;
+import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
+import org.folio.sidecar.support.extensions.InMemoryMessagingExtension;
+import org.folio.sidecar.support.profile.InMemoryMessagingTestProfile;
+import org.folio.support.types.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test verifying that cross-application egress routing is isolated per tenant.
+ *
+ * <p>Scenario: two applications share the same path ({@code /users/entities}) but provide it
+ * through different module versions:
+ * <ul>
+ *   <li>{@code app-platform-minimal-2.0.53} → {@code mod-users-19.5.4} at
+ *       {@code http://mod-users-19-5-4:8081}</li>
+ *   <li>{@code app-platform-complete-1.2.0} → {@code mod-users-19.6.0} at
+ *       {@code http://mod-users-19-6-0:8081}</li>
+ * </ul>
+ *
+ * <p>Tenant {@code diku2} is entitled only to {@code app-platform-minimal-2.0.53}, so its egress
+ * requests MUST resolve to {@code mod-users-19.5.4}. Tenant {@code diku-other} is entitled only to
+ * {@code app-platform-complete-1.2.0}, so its egress requests MUST resolve to
+ * {@code mod-users-19.6.0}.
+ */
+@IntegrationTest
+@TestProfile(InMemoryMessagingTestProfile.class)
+@QuarkusTestResource(value = InMemoryMessagingExtension.class, initArgs = {
+  @ResourceArg(value = "incoming", name = "entitlement")
+})
+class EgressIsolationIT {
+
+  private static final String APP_MINIMAL = "app-platform-minimal-2.0.53";
+  private static final String APP_COMPLETE = "app-platform-complete-1.2.0";
+
+  private static final String MOD_USERS_OLD_ID = "mod-users-19.5.4";
+  private static final String MOD_USERS_OLD_URL = "http://mod-users-19-5-4:8081";
+  private static final String MOD_USERS_NEW_ID = "mod-users-19.6.0";
+  private static final String MOD_USERS_NEW_URL = "http://mod-users-19-6-0:8081";
+
+  private static final String TENANT_MINIMAL = "diku2";
+  private static final String TENANT_COMPLETE = "diku-other";
+
+  private static final String USERS_PATH = "/users/entities";
+  private static final String USERS_INTERFACE = "users";
+
+  @InjectSpy
+  EgressRoutingLookup egressRoutingLookup;
+
+  @InjectMock
+  TenantService tenantService;
+
+  @BeforeEach
+  void setUp() {
+    // Bootstrap app-platform-minimal-2.0.53 with mod-users-19.5.4
+    egressRoutingLookup.onApplicationBootstrap(APP_MINIMAL,
+      List.of(discovery(MOD_USERS_OLD_ID, MOD_USERS_OLD_URL, APP_MINIMAL, USERS_INTERFACE, USERS_PATH,
+        List.of("GET", "POST"))));
+
+    // Bootstrap app-platform-complete-1.2.0 with mod-users-19.6.0
+    egressRoutingLookup.onApplicationBootstrap(APP_COMPLETE,
+      List.of(discovery(MOD_USERS_NEW_ID, MOD_USERS_NEW_URL, APP_COMPLETE, USERS_INTERFACE, USERS_PATH,
+        List.of("GET", "POST"))));
+
+    // diku2 is entitled only to the minimal app
+    when(tenantService.getApplicationIds(TENANT_MINIMAL)).thenReturn(Set.of(APP_MINIMAL));
+
+    // diku-other is entitled only to the complete app
+    when(tenantService.getApplicationIds(TENANT_COMPLETE)).thenReturn(Set.of(APP_COMPLETE));
+  }
+
+  @Test
+  void lookupRoute_diku2_resolvesToOldModUsers() {
+    var rc = routingContext(GET, TENANT_MINIMAL);
+
+    var result = egressRoutingLookup.lookupRoute(USERS_PATH, rc);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isPresent();
+    var entry = result.result().get();
+    assertThat(entry.getModuleId())
+      .as("diku2 must route to mod-users-19.5.4, not mod-users-19.6.0")
+      .isEqualTo(MOD_USERS_OLD_ID);
+    assertThat(entry.getLocation()).isEqualTo(MOD_USERS_OLD_URL);
+  }
+
+  @Test
+  void lookupRoute_dikuOther_resolvesToNewModUsers() {
+    var rc = routingContext(GET, TENANT_COMPLETE);
+
+    var result = egressRoutingLookup.lookupRoute(USERS_PATH, rc);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isPresent();
+    var entry = result.result().get();
+    assertThat(entry.getModuleId())
+      .as("diku-other must route to mod-users-19.6.0, not mod-users-19.5.4")
+      .isEqualTo(MOD_USERS_NEW_ID);
+    assertThat(entry.getLocation()).isEqualTo(MOD_USERS_NEW_URL);
+  }
+
+  @Test
+  void lookupRoute_diku2_doesNotSeeCompleteAppRoutes() {
+    // seed a route that only exists in app-complete
+    var completePath = "/complete-only/items";
+    egressRoutingLookup.onApplicationBootstrap(APP_COMPLETE,
+      List.of(discovery(MOD_USERS_NEW_ID, MOD_USERS_NEW_URL, APP_COMPLETE, "complete-iface",
+        completePath, List.of("GET"))));
+
+    var rc = routingContext(GET, TENANT_MINIMAL);
+    var result = egressRoutingLookup.lookupRoute(completePath, rc);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result())
+      .as("diku2 must not see routes from app-platform-complete-1.2.0")
+      .isEmpty();
+  }
+
+  @Test
+  void lookupRoute_dikuOther_doesNotSeeMinimalAppRoutes() {
+    // seed a route that only exists in app-minimal
+    var minimalPath = "/minimal-only/records";
+    egressRoutingLookup.onApplicationBootstrap(APP_MINIMAL,
+      List.of(discovery(MOD_USERS_OLD_ID, MOD_USERS_OLD_URL, APP_MINIMAL, "minimal-iface",
+        minimalPath, List.of("POST"))));
+
+    var rc = routingContext(POST, TENANT_COMPLETE);
+    var result = egressRoutingLookup.lookupRoute(minimalPath, rc);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result())
+      .as("diku-other must not see routes from app-platform-minimal-2.0.53")
+      .isEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private static RoutingContext routingContext(io.vertx.core.http.HttpMethod method, String tenant) {
+    var rc = mock(RoutingContext.class);
+    var req = mock(HttpServerRequest.class);
+    when(rc.request()).thenReturn(req);
+    when(req.method()).thenReturn(method);
+    lenient().when(req.getHeader(OkapiHeaders.TENANT)).thenReturn(tenant);
+    lenient().when(req.getHeader(OkapiHeaders.MODULE_ID)).thenReturn(null);
+    return rc;
+  }
+
+  private static ModuleBootstrapDiscovery discovery(String moduleId, String location,
+    String applicationId, String interfaceId, String pathPattern, List<String> methods) {
+    var endpoint = new ModuleBootstrapEndpoint();
+    endpoint.setPathPattern(pathPattern);
+    endpoint.setMethods(methods.toArray(new String[0]));
+
+    var iface = new ModuleBootstrapInterface();
+    iface.setId(interfaceId);
+    iface.setEndpoints(List.of(endpoint));
+
+    var d = new ModuleBootstrapDiscovery();
+    d.setModuleId(moduleId);
+    d.setLocation(location);
+    d.setApplicationId(applicationId);
+    d.setInterfaces(List.of(iface));
+    return d;
+  }
+}

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -1,5 +1,6 @@
 package org.folio.sidecar.it.kafka;
 
+import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
@@ -8,11 +9,13 @@ import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.support.TestConstants.TENANT_UUID;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.quarkus.test.InjectMock;
@@ -72,6 +75,46 @@ class TenantEntitlementConsumerIT {
     verify(tenantService).enableTenant(TENANT_NAME, APPLICATION_ID);
     verify(applicationManagerService).getModuleBootstrap(APPLICATION_ID);
     verify(egressRoutingLookup).onApplicationBootstrap(eq(APPLICATION_ID), anyList());
+  }
+
+  @Test
+  void consume_negative_notAssignedModule_noOp() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.ENTITLE, APPLICATION_ID);
+    doReturn(false).when(tenantService).isAssignedModule(MODULE_ID);
+
+    sendEvent(event);
+
+    awaitUntilAsserted(() -> verify(consumer).consume(event));
+    verify(tenantService, never()).enableTenant(any(), any());
+    verify(tenantService, never()).disableTenant(any(), any());
+    verifyNoInteractions(applicationManagerService, egressRoutingLookup);
+  }
+
+  @Test
+  void consume_positive_entitleEvent_bootstrapFails_logsWarning() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.ENTITLE, APPLICATION_ID);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
+    when(applicationManagerService.getModuleBootstrap(APPLICATION_ID))
+      .thenReturn(failedFuture(new RuntimeException("AM unreachable")));
+
+    sendEvent(event);
+
+    awaitUntilAsserted(() -> verify(consumer).consume(event));
+    verify(tenantService).enableTenant(TENANT_NAME, APPLICATION_ID);
+    verify(applicationManagerService).getModuleBootstrap(APPLICATION_ID);
+    verify(egressRoutingLookup, never()).onApplicationBootstrap(any(), any());
+  }
+
+  @Test
+  void consume_positive_revokeEvent_nullApplicationId_skipsEgressRevoke() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, null);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
+
+    sendEvent(event);
+
+    awaitUntilAsserted(() -> verify(consumer).consume(event));
+    verify(tenantService).disableTenant(TENANT_NAME, null);
+    verify(egressRoutingLookup, never()).onApplicationRevoked(any());
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -104,7 +104,7 @@ class TenantEntitlementConsumerIT {
   }
 
   @Test
-  void consume_positive_entitleEvent_bootstrapFails_logsWarning() {
+  void consume_negative_entitleEvent_bootstrapFails_doesNotEnableTenant() {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.ENTITLE, APPLICATION_ID);
     doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
     when(applicationManagerService.getModuleBootstrap(APPLICATION_ID))
@@ -113,7 +113,7 @@ class TenantEntitlementConsumerIT {
     sendEvent(event);
 
     awaitUntilAsserted(() -> verify(consumer).consume(event));
-    verify(tenantService).enableTenant(TENANT_NAME, APPLICATION_ID);
+    verify(tenantService, never()).enableTenant(TENANT_NAME, APPLICATION_ID);
     verify(applicationManagerService).getModuleBootstrap(APPLICATION_ID);
     verify(egressRoutingLookup, never()).onApplicationBootstrap(any(), any());
   }

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -2,6 +2,7 @@ package org.folio.sidecar.it.kafka;
 
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.folio.sidecar.support.TestConstants.APPLICATION_ID;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.support.TestConstants.TENANT_UUID;
@@ -49,24 +50,24 @@ class TenantEntitlementConsumerIT {
   @ParameterizedTest
   @EnumSource(value = Type.class, names = {"ENTITLE", "UPGRADE"})
   void consume_positive_entitleOrUpgradeEvent(Type type) {
-    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type, null);
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type, APPLICATION_ID);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
 
     sendEvent(event);
 
     awaitUntilAsserted(() -> verify(consumer).consume(event));
-    verify(tenantService).enableTenant(TENANT_NAME);
+    verify(tenantService).enableTenant(TENANT_NAME, APPLICATION_ID);
   }
 
   @Test
   void consume_positive_revokeEvent() {
-    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, null);
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, APPLICATION_ID);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
 
     sendEvent(event);
 
     awaitUntilAsserted(() -> verify(consumer).consume(event));
-    verify(tenantService).disableTenant(TENANT_NAME);
+    verify(tenantService).disableTenant(TENANT_NAME, APPLICATION_ID);
   }
 
   private void sendEvent(TenantEntitlementEvent event) {

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -10,6 +10,7 @@ import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.support.TestConstants.TENANT_UUID;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,7 +63,7 @@ class TenantEntitlementConsumerIT {
   @EnumSource(value = Type.class, names = {"ENTITLE", "UPGRADE"})
   void consume_positive_entitleOrUpgradeEvent(Type type) {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type, APPLICATION_ID);
-    when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
     when(applicationManagerService.getModuleBootstrap(APPLICATION_ID)).thenReturn(succeededFuture(MODULE_BOOTSTRAP));
 
     sendEvent(event);
@@ -76,9 +77,9 @@ class TenantEntitlementConsumerIT {
   @Test
   void consume_positive_revokeEvent_lastTenant_revokesEgressCache() {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, APPLICATION_ID);
-    when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
     // After disableTenant, no other tenant uses this applicationId
-    when(tenantService.getAllApplicationIds()).thenReturn(Collections.emptySet());
+    doReturn(Collections.emptySet()).when(tenantService).getAllApplicationIds();
 
     sendEvent(event);
 
@@ -90,9 +91,9 @@ class TenantEntitlementConsumerIT {
   @Test
   void consume_positive_revokeEvent_otherTenantPresent_keepsEgressCache() {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, APPLICATION_ID);
-    when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
     // Another tenant still uses this applicationId
-    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(APPLICATION_ID));
+    doReturn(Set.of(APPLICATION_ID)).when(tenantService).getAllApplicationIds();
 
     sendEvent(event);
 

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -1,11 +1,16 @@
 package org.folio.sidecar.it.kafka;
 
+import static io.vertx.core.Future.succeededFuture;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.folio.sidecar.support.TestConstants.APPLICATION_ID;
+import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP;
 import static org.folio.sidecar.support.TestConstants.MODULE_ID;
 import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.support.TestConstants.TENANT_UUID;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,12 +23,16 @@ import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import io.smallrye.reactive.messaging.memory.InMemorySource;
 import jakarta.enterprise.inject.Any;
 import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
+import org.folio.sidecar.integration.am.ApplicationManagerService;
 import org.folio.sidecar.integration.kafka.TenantEntitlementConsumer;
 import org.folio.sidecar.integration.kafka.TenantEntitlementEvent;
 import org.folio.sidecar.integration.kafka.TenantEntitlementEvent.Type;
 import org.folio.sidecar.service.TenantService;
+import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
 import org.folio.sidecar.support.extensions.EnableWireMock;
 import org.folio.sidecar.support.extensions.InMemoryMessagingExtension;
 import org.folio.sidecar.support.profile.InMemoryMessagingTestProfile;
@@ -42,6 +51,8 @@ class TenantEntitlementConsumerIT {
 
   @InjectSpy TenantEntitlementConsumer consumer;
   @InjectMock TenantService tenantService;
+  @InjectMock ApplicationManagerService applicationManagerService;
+  @InjectMock EgressRoutingLookup egressRoutingLookup;
 
   @Inject
   @Any
@@ -52,22 +63,42 @@ class TenantEntitlementConsumerIT {
   void consume_positive_entitleOrUpgradeEvent(Type type) {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type, APPLICATION_ID);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    when(applicationManagerService.getModuleBootstrap(APPLICATION_ID)).thenReturn(succeededFuture(MODULE_BOOTSTRAP));
 
     sendEvent(event);
 
     awaitUntilAsserted(() -> verify(consumer).consume(event));
     verify(tenantService).enableTenant(TENANT_NAME, APPLICATION_ID);
+    verify(applicationManagerService).getModuleBootstrap(APPLICATION_ID);
+    verify(egressRoutingLookup).onApplicationBootstrap(eq(APPLICATION_ID), anyList());
   }
 
   @Test
-  void consume_positive_revokeEvent() {
+  void consume_positive_revokeEvent_lastTenant_revokesEgressCache() {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, APPLICATION_ID);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    // After disableTenant, no other tenant uses this applicationId
+    when(tenantService.getAllApplicationIds()).thenReturn(Collections.emptySet());
 
     sendEvent(event);
 
     awaitUntilAsserted(() -> verify(consumer).consume(event));
     verify(tenantService).disableTenant(TENANT_NAME, APPLICATION_ID);
+    verify(egressRoutingLookup).onApplicationRevoked(APPLICATION_ID);
+  }
+
+  @Test
+  void consume_positive_revokeEvent_otherTenantPresent_keepsEgressCache() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, APPLICATION_ID);
+    when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
+    // Another tenant still uses this applicationId
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(APPLICATION_ID));
+
+    sendEvent(event);
+
+    awaitUntilAsserted(() -> verify(consumer).consume(event));
+    verify(tenantService).disableTenant(TENANT_NAME, APPLICATION_ID);
+    verify(egressRoutingLookup, never()).onApplicationRevoked(APPLICATION_ID);
   }
 
   private void sendEvent(TenantEntitlementEvent event) {

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -91,6 +91,19 @@ class TenantEntitlementConsumerIT {
   }
 
   @Test
+  void consume_positive_entitleEvent_nullApplicationId_skipsBootstrap() {
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.ENTITLE, null);
+    doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);
+
+    sendEvent(event);
+
+    awaitUntilAsserted(() -> verify(consumer).consume(event));
+    verify(tenantService).enableTenant(TENANT_NAME, null);
+    verifyNoInteractions(applicationManagerService);
+    verify(egressRoutingLookup, never()).onApplicationBootstrap(any(), any());
+  }
+
+  @Test
   void consume_positive_entitleEvent_bootstrapFails_logsWarning() {
     var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.ENTITLE, APPLICATION_ID);
     doReturn(true).when(tenantService).isAssignedModule(MODULE_ID);

--- a/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
+++ b/src/test/java/org/folio/sidecar/it/kafka/TenantEntitlementConsumerIT.java
@@ -49,7 +49,7 @@ class TenantEntitlementConsumerIT {
   @ParameterizedTest
   @EnumSource(value = Type.class, names = {"ENTITLE", "UPGRADE"})
   void consume_positive_entitleOrUpgradeEvent(Type type) {
-    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type);
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, type, null);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
 
     sendEvent(event);
@@ -60,7 +60,7 @@ class TenantEntitlementConsumerIT {
 
   @Test
   void consume_positive_revokeEvent() {
-    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE);
+    var event = TenantEntitlementEvent.of(MODULE_ID, TENANT_NAME, TENANT_UUID, Type.REVOKE, null);
     when(tenantService.isAssignedModule(MODULE_ID)).thenReturn(true);
 
     sendEvent(event);

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -317,7 +317,7 @@ class TenantServiceTest {
   }
 
   @Test
-  void init_positive_duplicateTenantIdsInEntitlements_firstApplicationIdWins() {
+  void init_positive_multipleApplicationsPerTenant_allRetained() {
     mockRetryTemplate();
     when(moduleProperties.getId()).thenReturn(TestConstants.MODULE_ID);
     when(tokenProvider.getAdminToken()).thenReturn(succeededFuture(TestConstants.AUTH_TOKEN));
@@ -334,7 +334,7 @@ class TenantServiceTest {
 
     assertThat(tenantService.isEnabledTenant(TestConstants.TENANT_NAME).result()).isTrue();
     assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME))
-      .containsAnyOf("app-first-1.0.0", "app-second-2.0.0");
+      .containsExactlyInAnyOrder("app-first-1.0.0", "app-second-2.0.0");
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -167,6 +167,14 @@ class TenantServiceTest {
   }
 
   @Test
+  void resetTaskFlag_positive_alreadyTrue_isNoOp() {
+    tenantService.resetTaskFlag(); // false → true
+    tenantService.resetTaskFlag(); // already true, no-op
+
+    verifyNoInteractions(tokenProvider, tenantEntitlementClient, tenantManagerClient, eventBus);
+  }
+
+  @Test
   void executeTenantsAndEntitlementsTask_positive() {
     mockRetryTemplate();
     when(moduleProperties.getId()).thenReturn(TestConstants.MODULE_ID);
@@ -306,6 +314,26 @@ class TenantServiceTest {
     tenantService.enableTenant("tenant1", "app-c-3.0.0");
     assertThat(tenantService.getAllApplicationIds())
       .containsExactlyInAnyOrder("app-a-1.0.0", "app-b-2.0.0", "app-c-3.0.0");
+  }
+
+  @Test
+  void init_positive_duplicateTenantIdsInEntitlements_firstApplicationIdWins() {
+    mockRetryTemplate();
+    when(moduleProperties.getId()).thenReturn(TestConstants.MODULE_ID);
+    when(tokenProvider.getAdminToken()).thenReturn(succeededFuture(TestConstants.AUTH_TOKEN));
+    var ent1 = Entitlement.of("app-first-1.0.0", TestConstants.TENANT_ID, emptyList());
+    var ent2 = Entitlement.of("app-second-2.0.0", TestConstants.TENANT_ID, emptyList());
+    when(tenantEntitlementClient.getModuleEntitlements(TestConstants.MODULE_ID, TestConstants.AUTH_TOKEN))
+      .thenReturn(succeededFuture(ResultList.asSinglePage(ent1, ent2)));
+
+    var tenant = Tenant.of(TestConstants.TENANT_UUID, TestConstants.TENANT_NAME, "tenant description");
+    when(tenantManagerClient.getTenantInfo(List.of(TestConstants.TENANT_ID), TestConstants.AUTH_TOKEN))
+      .thenReturn(succeededFuture(List.of(tenant)));
+
+    assertThatNoException().isThrownBy(() -> tenantService.init());
+
+    assertThat(tenantService.isEnabledTenant(TestConstants.TENANT_NAME).result()).isTrue();
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME)).containsAnyOf("app-first-1.0.0", "app-second-2.0.0");
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -333,7 +333,8 @@ class TenantServiceTest {
     assertThatNoException().isThrownBy(() -> tenantService.init());
 
     assertThat(tenantService.isEnabledTenant(TestConstants.TENANT_NAME).result()).isTrue();
-    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME)).containsAnyOf("app-first-1.0.0", "app-second-2.0.0");
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME))
+      .containsAnyOf("app-first-1.0.0", "app-second-2.0.0");
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -133,6 +133,31 @@ class TenantServiceTest {
   }
 
   @Test
+  void enableTenant_nullApplicationId_noOp() {
+    tenantService.enableTenant(TestConstants.TENANT_NAME, null);
+
+    verifyNoInteractions(eventBus);
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME)).isEmpty();
+  }
+
+  @Test
+  void disableTenant_nullApplicationId_noOp() {
+    tenantService.disableTenant(TestConstants.TENANT_NAME, null);
+
+    verifyNoInteractions(eventBus);
+  }
+
+  @Test
+  void getApplicationIds_nullTenantName_returnsEmpty() {
+    assertThat(tenantService.getApplicationIds(null)).isEmpty();
+  }
+
+  @Test
+  void getApplicationIds_unknownTenantName_returnsEmpty() {
+    assertThat(tenantService.getApplicationIds("unknown-tenant")).isEmpty();
+  }
+
+  @Test
   void disableTenant_negative_notEnabled() {
     tenantService.disableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
 

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -114,27 +114,27 @@ class TenantServiceTest {
   void enableAndThenDisableTenant_positive() {
     var inOrder = inOrder(eventBus);
     // enable
-    tenantService.enableTenant(TestConstants.TENANT_NAME);
+    tenantService.enableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
 
     inOrder.verify(eventBus).publish(EntitlementsEvent.ENTITLEMENTS_EVENT, tenantEntitlementsEvent());
 
     // disable
-    tenantService.disableTenant(TestConstants.TENANT_NAME);
+    tenantService.disableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
 
     inOrder.verify(eventBus).publish(EntitlementsEvent.ENTITLEMENTS_EVENT, emptyEntitlementsEvent());
   }
 
   @Test
   void enableTenant_negative_alreadyEnabled() {
-    tenantService.enableTenant(TestConstants.TENANT_NAME);
-    tenantService.enableTenant(TestConstants.TENANT_NAME);
+    tenantService.enableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
+    tenantService.enableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
 
     verify(eventBus, only()).publish(EntitlementsEvent.ENTITLEMENTS_EVENT, tenantEntitlementsEvent());
   }
 
   @Test
   void disableTenant_negative_notEnabled() {
-    tenantService.disableTenant(TestConstants.TENANT_NAME);
+    tenantService.disableTenant(TestConstants.TENANT_NAME, TestConstants.APPLICATION_ID);
 
     verifyNoInteractions(eventBus);
   }
@@ -234,6 +234,51 @@ class TenantServiceTest {
 
     verify(tenantEntitlementClient, times(2))
       .getModuleEntitlements(TestConstants.MODULE_ID, TestConstants.AUTH_TOKEN);
+  }
+
+  @Test
+  void enable_storesApplicationId() {
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    // tenant has at least one applicationId → it is in the map
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME))
+      .containsExactly("app-platform-minimal-2.0.53");
+    assertThat(tenantService.getAllApplicationIds()).containsExactly("app-platform-minimal-2.0.53");
+  }
+
+  @Test
+  void enable_multipleApplicationsForSameTenant() {
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-complete-1.2.0");
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME))
+      .containsExactlyInAnyOrder("app-platform-minimal-2.0.53", "app-platform-complete-1.2.0");
+  }
+
+  @Test
+  void disable_removesApplicationButKeepsTenantWhileOthersExist() {
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-complete-1.2.0");
+    tenantService.disableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME))
+      .containsExactly("app-platform-complete-1.2.0");
+    // tenant still has an app, so it remains in map
+    assertThat(tenantService.getAllApplicationIds()).containsExactly("app-platform-complete-1.2.0");
+  }
+
+  @Test
+  void disable_lastApplication_disablesTenant() {
+    tenantService.enableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    tenantService.disableTenant(TestConstants.TENANT_NAME, "app-platform-minimal-2.0.53");
+    assertThat(tenantService.getApplicationIds(TestConstants.TENANT_NAME)).isEmpty();
+    assertThat(tenantService.getAllApplicationIds()).isEmpty();
+  }
+
+  @Test
+  void getAllApplicationIds_returnsAllAcrossTenants() {
+    tenantService.enableTenant("tenant1", "app-a-1.0.0");
+    tenantService.enableTenant("tenant2", "app-b-2.0.0");
+    tenantService.enableTenant("tenant1", "app-c-3.0.0");
+    assertThat(tenantService.getAllApplicationIds())
+      .containsExactlyInAnyOrder("app-a-1.0.0", "app-b-2.0.0", "app-c-3.0.0");
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/TenantServiceTest.java
@@ -4,6 +4,7 @@ import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -19,6 +20,7 @@ import io.vertx.mutiny.core.eventbus.EventBus;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.folio.sidecar.configuration.properties.ModuleProperties;
 import org.folio.sidecar.integration.te.TenantEntitlementClient;
@@ -304,6 +306,26 @@ class TenantServiceTest {
     tenantService.enableTenant("tenant1", "app-c-3.0.0");
     assertThat(tenantService.getAllApplicationIds())
       .containsExactlyInAnyOrder("app-a-1.0.0", "app-b-2.0.0", "app-c-3.0.0");
+  }
+
+  @Test
+  void init_tenantManagerReturnsUnknownTenant_notAdded() {
+    mockRetryTemplate();
+    when(moduleProperties.getId()).thenReturn(TestConstants.MODULE_ID);
+    when(tokenProvider.getAdminToken()).thenReturn(succeededFuture(TestConstants.AUTH_TOKEN));
+    when(tenantEntitlementClient.getModuleEntitlements(TestConstants.MODULE_ID, TestConstants.AUTH_TOKEN))
+      .thenReturn(succeededFuture(
+        ResultList.asSinglePage(Entitlement.of(TestConstants.APPLICATION_ID, TestConstants.TENANT_ID, emptyList()))));
+
+    // TM returns a tenant whose UUID does not match any entitlement tenantId → appId == null in addEnabledTenants
+    var unknownUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    var unknownTenant = Tenant.of(unknownUuid, "unknown-tenant", "desc");
+    when(tenantManagerClient.getTenantInfo(List.of(TestConstants.TENANT_ID), TestConstants.AUTH_TOKEN))
+      .thenReturn(succeededFuture(List.of(unknownTenant)));
+
+    assertThatNoException().isThrownBy(() -> tenantService.init());
+
+    assertThat(tenantService.isEnabledTenant("unknown-tenant").result()).isFalse();
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -4,8 +4,11 @@ import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.INIT;
 import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.UPDATE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,10 +22,13 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.folio.sidecar.integration.am.ApplicationManagerService;
 import org.folio.sidecar.integration.am.model.ModuleBootstrap;
 import org.folio.sidecar.service.ModulePermissionsService;
+import org.folio.sidecar.service.TenantService;
+import org.folio.sidecar.service.routing.lookup.EgressRoutingLookup;
 import org.folio.sidecar.support.TestConstants;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
@@ -46,27 +52,29 @@ class RoutingServiceTest {
   @Mock private ModuleBootstrapListener listener1;
   @Mock private ModuleBootstrapListener listener2;
   @Mock private ModulePermissionsService modulePermissionsService;
+  @Mock private TenantService tenantService;
+  @Mock private EgressRoutingLookup egressLookup;
 
   @BeforeEach
   void setUp() {
     routingService = new RoutingService(appManagerService,
       List.of(requestHandler1, requestHandler2), List.of(listener1, listener2),
-      modulePermissionsService);
+      modulePermissionsService, tenantService, egressLookup);
   }
 
   @AfterEach
   void tearDown() {
     verifyNoMoreInteractions(appManagerService, requestHandler1, requestHandler2, listener1, listener2,
-      modulePermissionsService);
+      modulePermissionsService, tenantService, egressLookup);
   }
 
   @Test
   void constructor_negative_noRequestHandlers() {
     var listeners = List.of(listener1, listener2);
     var handlers = List.<Handler<RoutingContext>>of();
-    
+
     Assertions.assertThatThrownBy(() -> new RoutingService(appManagerService, handlers,
-        listeners, modulePermissionsService))
+        listeners, modulePermissionsService, tenantService, egressLookup))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Request handlers are not configured");
   }
@@ -74,8 +82,11 @@ class RoutingServiceTest {
   @Test
   void init_positive() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     var listenersOrder = inOrder(listener1, listener2);
@@ -87,6 +98,63 @@ class RoutingServiceTest {
     verifyHandlers(routeOrder);
 
     verify(modulePermissionsService).putPermissions(anySet());
+    verify(tenantService).getAllApplicationIds();
+    verify(appManagerService).getModuleBootstrap(appId);
+    verify(egressLookup).onApplicationBootstrap(eq(appId), eq(bootstrap.getRequiredModules()));
+  }
+
+  @Test
+  void init_positive_multipleApplications() {
+    var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+    var appId1 = TestConstants.APPLICATION_ID;
+    var appId2 = "application-1.0.0";
+
+    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId1)).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId2)).thenReturn(succeededFuture(bootstrap));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId1, appId2));
+    when(router.route("/*")).thenReturn(route);
+
+    routingService.init(router);
+
+    verify(tenantService).getAllApplicationIds();
+    verify(appManagerService).getModuleBootstrap(appId1);
+    verify(appManagerService).getModuleBootstrap(appId2);
+    verify(egressLookup).onApplicationBootstrap(eq(appId1), eq(bootstrap.getRequiredModules()));
+    verify(egressLookup).onApplicationBootstrap(eq(appId2), eq(bootstrap.getRequiredModules()));
+    verify(appManagerService).getModuleBootstrap();
+    verify(modulePermissionsService).putPermissions(anySet());
+    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    // router setup
+    verify(router).route("/*");
+    verify(route).handler(requestHandler1);
+    verify(route).handler(requestHandler2);
+  }
+
+  @Test
+  void init_positive_noApplications() {
+    var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+
+    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of());
+    when(router.route("/*")).thenReturn(route);
+
+    routingService.init(router);
+
+    verify(tenantService).getAllApplicationIds();
+    verify(egressLookup, never()).onApplicationBootstrap(any(), any());
+    verify(appManagerService).getModuleBootstrap();
+    verify(modulePermissionsService).putPermissions(anySet());
+    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    verify(router).route("/*");
+    verify(route).handler(requestHandler1);
+    verify(route).handler(requestHandler2);
   }
 
   @Test
@@ -95,18 +163,23 @@ class RoutingServiceTest {
 
     routingService.init(router);
 
-    verifyNoInteractions(router);
+    verifyNoInteractions(router, tenantService, egressLookup);
   }
 
   @Test
   void updateModuleRoutes_positive_updateIngressRoutes() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     routingService.init(router);
-    reset(listener1, listener2, router, route);
+    reset(listener1, listener2, router, route, tenantService, egressLookup, appManagerService);
+
+    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
 
     var listenersOrder = inOrder(listener1, listener2);
 
@@ -120,12 +193,17 @@ class RoutingServiceTest {
   @Test
   void updateModuleRoutes_positive_updateEgressRoutes() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     routingService.init(router);
-    reset(listener1, listener2, router, route);
+    reset(listener1, listener2, router, route, tenantService, egressLookup, appManagerService);
+
+    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
 
     var listenersOrder = inOrder(listener1, listener2);
 
@@ -139,7 +217,7 @@ class RoutingServiceTest {
   @Test
   void updateModuleRoutes_negative_moduleNotFound() {
     routingService.updateModuleRoutes("unknown_module");
-    verifyNoInteractions(appManagerService, listener1, listener2, router, route);
+    verifyNoInteractions(appManagerService, listener1, listener2, router, route, tenantService, egressLookup);
   }
 
   private void verifyHandlers(InOrder routeOrder) {

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -167,6 +167,33 @@ class RoutingServiceTest {
   }
 
   @Test
+  void init_positive_applicationBootstrapFails_logsWarningAndContinues() {
+    var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+    var appId = TestConstants.APPLICATION_ID;
+
+    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+    when(appManagerService.getModuleBootstrap(appId))
+      .thenReturn(failedFuture(new RuntimeException("AM unreachable")));
+    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
+    when(router.route("/*")).thenReturn(route);
+
+    routingService.init(router);
+
+    verify(tenantService).getAllApplicationIds();
+    verify(appManagerService).getModuleBootstrap(appId);
+    verify(egressLookup, never()).onApplicationBootstrap(any(), any());
+    verify(appManagerService).getModuleBootstrap();
+    verify(modulePermissionsService).putPermissions(anySet());
+    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
+    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
+    verify(router).route("/*");
+    verify(route).handler(requestHandler1);
+    verify(route).handler(requestHandler2);
+  }
+
+  @Test
   void updateModuleRoutes_positive_updateIngressRoutes() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
     var appId = TestConstants.APPLICATION_ID;

--- a/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/RoutingServiceTest.java
@@ -6,7 +6,6 @@ import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeTy
 import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.UPDATE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -82,11 +81,8 @@ class RoutingServiceTest {
   @Test
   void init_positive() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
-    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
-    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
-    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     var listenersOrder = inOrder(listener1, listener2);
@@ -98,63 +94,39 @@ class RoutingServiceTest {
     verifyHandlers(routeOrder);
 
     verify(modulePermissionsService).putPermissions(anySet());
-    verify(tenantService).getAllApplicationIds();
-    verify(appManagerService).getModuleBootstrap(appId);
-    verify(egressLookup).onApplicationBootstrap(eq(appId), eq(bootstrap.getRequiredModules()));
+    // init must NOT call loadEgressBootstrapPerApplication itself; SidecarInitializer orchestrates that
+    verifyNoInteractions(tenantService, egressLookup);
+    verify(appManagerService).getModuleBootstrap();
   }
 
   @Test
-  void init_positive_multipleApplications() {
+  void loadEgressBootstrapPerApplication_positive_multipleApplications() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
     var appId1 = TestConstants.APPLICATION_ID;
     var appId2 = "application-1.0.0";
 
-    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
     when(appManagerService.getModuleBootstrap(appId1)).thenReturn(succeededFuture(bootstrap));
     when(appManagerService.getModuleBootstrap(appId2)).thenReturn(succeededFuture(bootstrap));
     when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId1, appId2));
-    when(router.route("/*")).thenReturn(route);
 
-    routingService.init(router);
+    routingService.loadEgressBootstrapPerApplication();
 
     verify(tenantService).getAllApplicationIds();
     verify(appManagerService).getModuleBootstrap(appId1);
     verify(appManagerService).getModuleBootstrap(appId2);
-    verify(egressLookup).onApplicationBootstrap(eq(appId1), eq(bootstrap.getRequiredModules()));
-    verify(egressLookup).onApplicationBootstrap(eq(appId2), eq(bootstrap.getRequiredModules()));
-    verify(appManagerService).getModuleBootstrap();
-    verify(modulePermissionsService).putPermissions(anySet());
-    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    // router setup
-    verify(router).route("/*");
-    verify(route).handler(requestHandler1);
-    verify(route).handler(requestHandler2);
+    verify(egressLookup).onApplicationBootstrap(appId1, bootstrap.getRequiredModules());
+    verify(egressLookup).onApplicationBootstrap(appId2, bootstrap.getRequiredModules());
   }
 
   @Test
-  void init_positive_noApplications() {
-    var bootstrap = TestConstants.MODULE_BOOTSTRAP;
-
-    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
+  void loadEgressBootstrapPerApplication_positive_noApplications() {
     when(tenantService.getAllApplicationIds()).thenReturn(Set.of());
-    when(router.route("/*")).thenReturn(route);
 
-    routingService.init(router);
+    routingService.loadEgressBootstrapPerApplication();
 
     verify(tenantService).getAllApplicationIds();
     verify(egressLookup, never()).onApplicationBootstrap(any(), any());
-    verify(appManagerService).getModuleBootstrap();
-    verify(modulePermissionsService).putPermissions(anySet());
-    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(router).route("/*");
-    verify(route).handler(requestHandler1);
-    verify(route).handler(requestHandler2);
+    verifyNoInteractions(appManagerService);
   }
 
   @Test
@@ -167,40 +139,25 @@ class RoutingServiceTest {
   }
 
   @Test
-  void init_positive_applicationBootstrapFails_logsWarningAndContinues() {
-    var bootstrap = TestConstants.MODULE_BOOTSTRAP;
+  void loadEgressBootstrapPerApplication_positive_applicationBootstrapFails_logsWarningAndContinues() {
     var appId = TestConstants.APPLICATION_ID;
 
-    when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
     when(appManagerService.getModuleBootstrap(appId))
       .thenReturn(failedFuture(new RuntimeException("AM unreachable")));
     when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
-    when(router.route("/*")).thenReturn(route);
 
-    routingService.init(router);
+    routingService.loadEgressBootstrapPerApplication();
 
     verify(tenantService).getAllApplicationIds();
     verify(appManagerService).getModuleBootstrap(appId);
     verify(egressLookup, never()).onApplicationBootstrap(any(), any());
-    verify(appManagerService).getModuleBootstrap();
-    verify(modulePermissionsService).putPermissions(anySet());
-    verify(listener1).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener1).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(listener2).onModuleBootstrap(bootstrap.getModule(), INIT);
-    verify(listener2).onRequiredModulesBootstrap(bootstrap.getRequiredModules(), INIT);
-    verify(router).route("/*");
-    verify(route).handler(requestHandler1);
-    verify(route).handler(requestHandler2);
   }
 
   @Test
   void updateModuleRoutes_positive_updateIngressRoutes() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
-    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
-    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
-    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     routingService.init(router);
@@ -220,11 +177,8 @@ class RoutingServiceTest {
   @Test
   void updateModuleRoutes_positive_updateEgressRoutes() {
     var bootstrap = TestConstants.MODULE_BOOTSTRAP;
-    var appId = TestConstants.APPLICATION_ID;
 
     when(appManagerService.getModuleBootstrap()).thenReturn(succeededFuture(bootstrap));
-    when(appManagerService.getModuleBootstrap(appId)).thenReturn(succeededFuture(bootstrap));
-    when(tenantService.getAllApplicationIds()).thenReturn(Set.of(appId));
     when(router.route("/*")).thenReturn(route);
 
     routingService.init(router);

--- a/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
@@ -85,6 +85,33 @@ class EgressRoutingLookupTest {
   }
 
   @Test
+  void lookupRoute_overlappingPaths_sortedAppIdWins_deterministic() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+
+    // Two apps both expose the same path/method
+    var app1Discovery = buildDiscovery("mod-alpha-1.0.0", "http://mod-alpha:8081", "app-alpha-1.0.0",
+      "common", null, "/common/items", List.of("GET"));
+    var app2Discovery = buildDiscovery("mod-beta-1.0.0", "http://mod-beta:8081", "app-beta-1.0.0",
+      "common", null, "/common/items", List.of("GET"));
+
+    egressLookup.onApplicationBootstrap("app-alpha-1.0.0", List.of(app1Discovery));
+    egressLookup.onApplicationBootstrap("app-beta-1.0.0", List.of(app2Discovery));
+
+    // Tenant entitled to both apps
+    when(tenantService.getApplicationIds("tenant-x"))
+      .thenReturn(Set.of("app-alpha-1.0.0", "app-beta-1.0.0"));
+
+    var result1 = egressLookup.lookupRoute("/common/items", routingContext(GET, "tenant-x"));
+    var result2 = egressLookup.lookupRoute("/common/items", routingContext(GET, "tenant-x"));
+
+    // Both calls must return a result and it must be the same module (sorted: app-alpha before app-beta)
+    assertThat(result1.result()).isPresent();
+    assertThat(result2.result()).isPresent();
+    assertThat(result1.result().get().getModuleId()).isEqualTo(result2.result().get().getModuleId());
+    assertThat(result1.result().get().getModuleId()).isEqualTo("mod-alpha-1.0.0");
+  }
+
+  @Test
   void lookupRoute_perApplicationIsolation_tenantSeesOnlyItsAppRoutes() {
     egressLookup = new EgressRoutingLookup(tenantService);
 

--- a/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
@@ -101,9 +101,9 @@ class EgressRoutingLookupTest {
     assertThat(resultA.result()).isPresent();
     assertThat(resultA.result().get().getModuleId()).isEqualTo("mod-bar-0.5.1");
 
-    var resultAMiss = egressLookup.lookupRoute("/baz/items", rcA);
-    assertThat(resultAMiss.succeeded()).isTrue();
-    assertThat(resultAMiss.result()).isEmpty();
+    var missingRouteA = egressLookup.lookupRoute("/baz/items", rcA);
+    assertThat(missingRouteA.succeeded()).isTrue();
+    assertThat(missingRouteA.result()).isEmpty();
 
     // tenant-b is only entitled to app-2 → sees baz route, not bar
     when(tenantService.getApplicationIds("tenant-b")).thenReturn(Set.of("app-2"));
@@ -113,9 +113,9 @@ class EgressRoutingLookupTest {
     assertThat(resultB.result()).isPresent();
     assertThat(resultB.result().get().getModuleId()).isEqualTo("mod-baz-0.5.1");
 
-    var resultBMiss = egressLookup.lookupRoute("/bar/entities", rcB);
-    assertThat(resultBMiss.succeeded()).isTrue();
-    assertThat(resultBMiss.result()).isEmpty();
+    var missingRouteB = egressLookup.lookupRoute("/bar/entities", rcB);
+    assertThat(missingRouteB.succeeded()).isTrue();
+    assertThat(missingRouteB.result()).isEmpty();
   }
 
   @Test

--- a/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
@@ -6,10 +6,8 @@ import static io.vertx.core.http.HttpMethod.PATCH;
 import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpMethod.PUT;
 import static java.lang.String.format;
-import static java.util.List.of;
 import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.INIT;
 import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP_EGRESS;
 import static org.folio.sidecar.support.TestValues.routingEntryWithPerms;
 import static org.folio.sidecar.utils.CollectionUtils.safeList;
@@ -23,14 +21,21 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapDiscovery;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapEndpoint;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapInterface;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
 import org.folio.sidecar.model.ScRoutingEntry;
+import org.folio.sidecar.service.TenantService;
 import org.folio.support.types.UnitTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
@@ -40,14 +45,19 @@ class EgressRoutingLookupTest {
   private static final Module MOD_BAR = new Module("mod-bar-0.5.1", "http://mod-bar:8081");
   private static final Module MOD_BAZ = new Module("mod-baz-0.5.1", "http://mod-baz:8081");
 
-  private final EgressRoutingLookup egressLookup = new EgressRoutingLookup();
+  @Mock
+  private TenantService tenantService;
+
+  private EgressRoutingLookup egressLookup;
 
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   @MethodSource("egressRequestDataProvider")
   void lookupForEgressRequest_parameterized(HttpMethod method, String path, ScRoutingEntry expected) {
-    egressLookup.onRequiredModulesBootstrap(MODULE_BOOTSTRAP_EGRESS.getRequiredModules(), INIT);
+    egressLookup = new EgressRoutingLookup(tenantService);
+    when(tenantService.getApplicationIds("testtenant")).thenReturn(Set.of("application-0.0.1"));
+    egressLookup.onApplicationBootstrap("application-0.0.1", MODULE_BOOTSTRAP_EGRESS.getRequiredModules());
 
-    var actual = egressLookup.lookupRoute(path, routingContext(method));
+    var actual = egressLookup.lookupRoute(path, routingContext(method, "testtenant"));
 
     assertThat(actual.succeeded()).isTrue();
     assertThat(actual.result()).isEqualTo(ofNullable(expected));
@@ -57,8 +67,10 @@ class EgressRoutingLookupTest {
   @MethodSource("egressRequestMultiDataProvider")
   void lookupForEgressRequestMulti_parameterized(HttpMethod method, String path, Module module,
     ScRoutingEntry expected) {
-    egressLookup.onRequiredModulesBootstrap(MODULE_BOOTSTRAP_EGRESS.getRequiredModules(), INIT);
-    var rc = routingContext(method);
+    egressLookup = new EgressRoutingLookup(tenantService);
+    when(tenantService.getApplicationIds("testtenant")).thenReturn(Set.of("application-0.0.1"));
+    egressLookup.onApplicationBootstrap("application-0.0.1", MODULE_BOOTSTRAP_EGRESS.getRequiredModules());
+    var rc = routingContext(method, "testtenant");
     if (module != null) {
       lenient().when(rc.request().getHeader(OkapiHeaders.MODULE_ID)).thenReturn(module.id());
     }
@@ -69,19 +81,78 @@ class EgressRoutingLookupTest {
     assertThat(actual.result()).isEqualTo(ofNullable(expected));
   }
 
+  @Test
+  void lookupRoute_perApplicationIsolation_tenantSeesOnlyItsAppRoutes() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+
+    var barDiscovery = buildDiscovery("mod-bar-0.5.1", "http://mod-bar:8081", "app-1",
+      "bar", null, "/bar/entities", List.of("POST"));
+    var bazDiscovery = buildDiscovery("mod-baz-0.5.1", "http://mod-baz:8081", "app-2",
+      "baz", null, "/baz/items", List.of("GET"));
+
+    egressLookup.onApplicationBootstrap("app-1", List.of(barDiscovery));
+    egressLookup.onApplicationBootstrap("app-2", List.of(bazDiscovery));
+
+    // tenant-a is only entitled to app-1 → sees bar route, not baz
+    when(tenantService.getApplicationIds("tenant-a")).thenReturn(Set.of("app-1"));
+    var rcA = routingContext(POST, "tenant-a");
+    var resultA = egressLookup.lookupRoute("/bar/entities", rcA);
+    assertThat(resultA.succeeded()).isTrue();
+    assertThat(resultA.result()).isPresent();
+    assertThat(resultA.result().get().getModuleId()).isEqualTo("mod-bar-0.5.1");
+
+    var resultAMiss = egressLookup.lookupRoute("/baz/items", rcA);
+    assertThat(resultAMiss.succeeded()).isTrue();
+    assertThat(resultAMiss.result()).isEmpty();
+
+    // tenant-b is only entitled to app-2 → sees baz route, not bar
+    when(tenantService.getApplicationIds("tenant-b")).thenReturn(Set.of("app-2"));
+    var rcB = routingContext(GET, "tenant-b");
+    var resultB = egressLookup.lookupRoute("/baz/items", rcB);
+    assertThat(resultB.succeeded()).isTrue();
+    assertThat(resultB.result()).isPresent();
+    assertThat(resultB.result().get().getModuleId()).isEqualTo("mod-baz-0.5.1");
+
+    var resultBMiss = egressLookup.lookupRoute("/bar/entities", rcB);
+    assertThat(resultBMiss.succeeded()).isTrue();
+    assertThat(resultBMiss.result()).isEmpty();
+  }
+
+  @Test
+  void lookupRoute_afterApplicationRevoked_routesAreGone() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+
+    var barDiscovery = buildDiscovery("mod-bar-0.5.1", "http://mod-bar:8081", "app-1",
+      "bar", null, "/bar/entities", List.of("POST"));
+    egressLookup.onApplicationBootstrap("app-1", List.of(barDiscovery));
+
+    when(tenantService.getApplicationIds("tenant-a")).thenReturn(Set.of("app-1"));
+    var rcA = routingContext(POST, "tenant-a");
+
+    var before = egressLookup.lookupRoute("/bar/entities", rcA);
+    assertThat(before.result()).isPresent();
+
+    egressLookup.onApplicationRevoked("app-1");
+
+    // route must be gone even if TenantService still lists the app (the cache entry was removed)
+    var after = egressLookup.lookupRoute("/bar/entities", rcA);
+    assertThat(after.succeeded()).isTrue();
+    assertThat(after.result()).isEmpty();
+  }
+
   static Stream<Arguments> egressRequestDataProvider() {
     String id = "00000000-0000-0000-0000-000000000000";
     return Stream.of(
       arguments(GET, null, null),
-      arguments(POST, "/bar/entities", scRoutingEntry("bar", "/bar/entities", of(POST), of("item.post"))),
+      arguments(POST, "/bar/entities", scRoutingEntry("bar", "/bar/entities", List.of(POST), List.of("item.post"))),
       arguments(GET, format("/bar/entities/%s", id),
-        scRoutingEntry("bar", "/bar/entities/{id}", of(GET), of("item.get"))),
+        scRoutingEntry("bar", "/bar/entities/{id}", List.of(GET), List.of("item.get"))),
       arguments(PUT, format("/bar/entities/%s", id),
-        scRoutingEntry("bar", "/bar/entities/{id}", of(PUT), of("item.put"))),
+        scRoutingEntry("bar", "/bar/entities/{id}", List.of(PUT), List.of("item.put"))),
       arguments(POST, format("/bar/entities/%s", id), null),
       arguments(PATCH, format("/bar/entities/%s", id), null),
       arguments(DELETE, format("/bar/entities/%s", id),
-        scRoutingEntry("bar", "/bar/entities/{id}", of(DELETE), of("item.delete")))
+        scRoutingEntry("bar", "/bar/entities/{id}", List.of(DELETE), List.of("item.delete")))
     );
   }
 
@@ -90,13 +161,13 @@ class EgressRoutingLookupTest {
     return Stream.of(
       arguments(GET, null, MOD_BAZ, null),
       arguments(POST, "/bam/multi/entities", MOD_BAR,
-        scRoutingEntryMulti(MOD_BAR, "bam", "/bam/multi/entities", of(GET, POST), of("multi.collection"))),
+        scRoutingEntryMulti(MOD_BAR, "bam", "/bam/multi/entities", List.of(GET, POST), List.of("multi.collection"))),
       arguments(GET, "/bam/multi/entities", MOD_BAZ,
-        scRoutingEntryMulti(MOD_BAZ, "bam", "/bam/multi/entities", of(GET, POST), of("multi.collection"))),
+        scRoutingEntryMulti(MOD_BAZ, "bam", "/bam/multi/entities", List.of(GET, POST), List.of("multi.collection"))),
       arguments(GET, format("/bam/multi/entities/%s", id), MOD_BAZ,
-        scRoutingEntryMulti(MOD_BAZ, "bam", "/bam/multi/entities/{id}", of(GET), of("multi.item.get"))),
+        scRoutingEntryMulti(MOD_BAZ, "bam", "/bam/multi/entities/{id}", List.of(GET), List.of("multi.item.get"))),
       arguments(GET, format("/bam/multi/entities/%s", id), MOD_BAR,
-        scRoutingEntryMulti(MOD_BAR, "bam", "/bam/multi/entities/{id}", of(GET), of("multi.item.get"))),
+        scRoutingEntryMulti(MOD_BAR, "bam", "/bam/multi/entities/{id}", List.of(GET), List.of("multi.item.get"))),
 
       arguments(GET, format("/bar/entities/%s", id), MOD_BAZ, null),
       arguments(DELETE, "/bam/multi/entities", MOD_BAR, null),
@@ -121,12 +192,32 @@ class EgressRoutingLookupTest {
     return scRoutingEntry(module, interfaceId, MULTIPLE_INTERFACE_TYPE, pathPattern, httpMethods, requiredPermissions);
   }
 
-  private static RoutingContext routingContext(HttpMethod method) {
+  private static RoutingContext routingContext(HttpMethod method, String tenant) {
     var routingContext = mock(RoutingContext.class);
     var request = mock(HttpServerRequest.class);
     when(routingContext.request()).thenReturn(request);
     when(request.method()).thenReturn(method);
+    lenient().when(request.getHeader(OkapiHeaders.TENANT)).thenReturn(tenant);
     return routingContext;
+  }
+
+  private static ModuleBootstrapDiscovery buildDiscovery(String moduleId, String location, String applicationId,
+    String interfaceId, String interfaceType, String pathPattern, List<String> methods) {
+    var endpoint = new ModuleBootstrapEndpoint();
+    endpoint.setPathPattern(pathPattern);
+    endpoint.setMethods(methods.toArray(new String[0]));
+
+    var iface = new ModuleBootstrapInterface();
+    iface.setId(interfaceId);
+    iface.setInterfaceType(interfaceType);
+    iface.setEndpoints(List.of(endpoint));
+
+    var discovery = new ModuleBootstrapDiscovery();
+    discovery.setModuleId(moduleId);
+    discovery.setLocation(location);
+    discovery.setApplicationId(applicationId);
+    discovery.setInterfaces(List.of(iface));
+    return discovery;
   }
 
   private record Module(String id, String url) {

--- a/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
+++ b/src/test/java/org/folio/sidecar/service/routing/lookup/EgressRoutingLookupTest.java
@@ -8,6 +8,8 @@ import static io.vertx.core.http.HttpMethod.PUT;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.INIT;
+import static org.folio.sidecar.service.routing.ModuleBootstrapListener.ChangeType.UPDATE;
 import static org.folio.sidecar.support.TestConstants.MODULE_BOOTSTRAP_EGRESS;
 import static org.folio.sidecar.support.TestValues.routingEntryWithPerms;
 import static org.folio.sidecar.utils.CollectionUtils.safeList;
@@ -20,6 +22,7 @@ import static org.mockito.Mockito.when;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -116,6 +119,40 @@ class EgressRoutingLookupTest {
     var missingRouteB = egressLookup.lookupRoute("/bar/entities", rcB);
     assertThat(missingRouteB.succeeded()).isTrue();
     assertThat(missingRouteB.result()).isEmpty();
+  }
+
+  @Test
+  void onRequiredModulesBootstrap_null_noOp() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+    egressLookup.onRequiredModulesBootstrap(null, INIT);
+
+    when(tenantService.getApplicationIds("tenant-a")).thenReturn(Set.of("app-1"));
+    var result = egressLookup.lookupRoute("/any/path", routingContext(GET, "tenant-a"));
+    assertThat(result.result()).isEmpty();
+  }
+
+  @Test
+  void onRequiredModulesBootstrap_empty_noOp() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+    egressLookup.onRequiredModulesBootstrap(Collections.emptyList(), INIT);
+
+    when(tenantService.getApplicationIds("tenant-a")).thenReturn(Set.of("app-1"));
+    var result = egressLookup.lookupRoute("/any/path", routingContext(GET, "tenant-a"));
+    assertThat(result.result()).isEmpty();
+  }
+
+  @Test
+  void onRequiredModulesBootstrap_update_populatesCache() {
+    egressLookup = new EgressRoutingLookup(tenantService);
+    var discovery = buildDiscovery("mod-bar-0.5.1", "http://mod-bar:8081", "app-1",
+      "bar", null, "/bar/entities", List.of("POST"));
+
+    egressLookup.onRequiredModulesBootstrap(List.of(discovery), UPDATE);
+
+    when(tenantService.getApplicationIds("tenant-a")).thenReturn(Set.of("app-1"));
+    var result = egressLookup.lookupRoute("/bar/entities", routingContext(POST, "tenant-a"));
+    assertThat(result.result()).isPresent();
+    assertThat(result.result().get().getModuleId()).isEqualTo("mod-bar-0.5.1");
   }
 
   @Test


### PR DESCRIPTION
## EUREKASUP-156: Multi-version module deployment – per-application egress routing

### Purpose

The sidecar maintained a single flat egress routing cache shared across all applications, causing it to select the wrong module version when multiple applications with conflicting module versions coexist in the same cluster (e.g. `mod-users-19.5.4` from `app-platform-minimal` vs. `mod-users-19.6.0` from `app-platform-complete`). This change makes routing per-application so each tenant is served only from the modules belonging to its entitled applications.

US: [EUREKASUP-156](https://folio-org.atlassian.net/browse/EUREKASUP-156)

### Approach

Replaced the single flat egress cache with a `Map<applicationId, routingTable>`. `TenantService` now tracks which applicationIds each tenant is entitled to. At startup and on Kafka entitlement events, the sidecar fetches bootstrap per-application from `mgr-applications` and stores one routing table per application. Route lookup searches only the tables for the requesting tenant's entitled applications.

**Implementation details:**

- Added `applicationId` field to `TenantEntitlementEvent` with `@JsonIgnoreProperties(ignoreUnknown = true)` to handle legacy Kafka events that lack the field.
- Replaced `Set<String> enabledTenants` in `TenantService` with `Map<String, Set<String>> tenantApplications` (tenant name → set of applicationIds). Added `enableTenant(name, applicationId)` / `disableTenant(name, applicationId)`, `getApplicationIds(tenantName)`, and `getAllApplicationIds()`; null `applicationId` is a no-op with a warning to preserve compatibility with legacy events. `getEnabledTenants()` and `isEnabledTenant()` continue to work via `tenantApplications.keySet()`.
- Refactored `EgressRoutingLookup` to maintain `Map<applicationId, Map<path, List<ScRoutingEntry>>> cachePerApplication`. Added `onApplicationBootstrap(applicationId, modules)` and `onApplicationRevoked(applicationId)`. The `lookupRoute` method reads `X-Okapi-Tenant`, resolves the tenant's applicationIds from `TenantService`, and searches only those per-app tables. `onRequiredModulesBootstrap` is kept as a backward-compatible shim that groups modules by `applicationId` and delegates to `onApplicationBootstrap`.
- Added `ApplicationManagerClient.getModuleBootstrap(moduleId, applicationId, token)` 3-argument overload that appends `?applicationId=<value>` to the URL; the existing 2-argument overload delegates to it with `null`.
- Added `ApplicationManagerService.getModuleBootstrap(applicationId)` overload that wires the 3-argument client call through the existing retry template.
- Changed `RoutingService.init` to call `loadEgressBootstrapPerApplication()` after ingress route registration: iterates `tenantService.getAllApplicationIds()` and calls `onApplicationBootstrap` per application.
- Changed `TenantEntitlementConsumer` to call `enableTenant(name, applicationId)` / `disableTenant(name, applicationId)` and on ENTITLE to fetch bootstrap for the specific `applicationId` and populate `EgressRoutingLookup`; on REVOKE to call `onApplicationRevoked` if no other tenant still references that application. Null `applicationId` guards prevent NPEs from legacy events.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.