### PR TITLE
MODSIDECAR-182 - Migrate UMA Permission Checks to Response Mode Decision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Changes:
 * Invalidate system token cache on egress 401 and return 503 with Retry-After header ([MODSIDECAR-178](https://folio-org.atlassian.net/browse/MODSIDECAR-178))
 * Adjust Keycloak error handling ([MODSIDECAR-192](https://folio-org.atlassian.net/browse/MODSIDECAR-192))
+* Migrate UMA Permission Checks to Response Mode Decision ([MODSIDECAR-182](https://folio-org.atlassian.net/browse/MODSIDECAR-182))
 
 ## Version `v4.0.0` (16.04.2026)
 ### Changes:

--- a/README.md
+++ b/README.md
@@ -436,16 +436,17 @@ Required when `SECRET_STORE_TYPE=FSSP`
 * Extract tenant from token and compare it with `x-okapi-tenant`
 * Extract `user_id` JWT claim from token and put it as `x-okapi-user-id` header if not set (the JWT claim is mapped from
   corresponding keycloak user attribute).
-* Send authorization request to Keycloak for exchanging access token for RPT. If RPT response is ok, then access is
+* Send authorization request to Keycloak for evaluating the UMA decision. If the response is ok, then access is
   granted and the token is cached until expired.
-    * RPT request example:
+    * UMA decision request example:
   ```shell
   curl --location --request POST '<keycloak>/realms/diku/protocol/openid-connect/token' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --header 'Authorization: Bearer <okapiToken>' \
   --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:uma-ticket' \
   --data-urlencode 'audience=diku-login-application' \
-  --data-urlencode 'permission=/users#GET'
+  --data-urlencode 'permission=/users#GET' \
+  --data-urlencode 'response_mode=decision'
   ```
 
 ### Egress

--- a/src/main/java/org/folio/sidecar/integration/keycloak/KeycloakClient.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/KeycloakClient.java
@@ -5,7 +5,7 @@ import static org.folio.sidecar.utils.TokenRequestHelper.prepareImpersonateReque
 import static org.folio.sidecar.utils.TokenRequestHelper.prepareIntrospectRequestBody;
 import static org.folio.sidecar.utils.TokenRequestHelper.preparePasswordRequestBody;
 import static org.folio.sidecar.utils.TokenRequestHelper.prepareRefreshRequestBody;
-import static org.folio.sidecar.utils.TokenRequestHelper.prepareRptRequestBody;
+import static org.folio.sidecar.utils.TokenRequestHelper.prepareUmaDecisionRequestBody;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -50,7 +50,7 @@ public class KeycloakClient {
 
   public Future<HttpResponse<Buffer>> evaluatePermissions(String tenant, String permission, String accessToken) {
     var clientId = tenant + properties.getLoginClientSuffix();
-    var requestBody = prepareRptRequestBody(clientId, permission);
+    var requestBody = prepareUmaDecisionRequestBody(clientId, permission);
     return webClient.postAbs(resolveTokenUrl(tenant))
       .bearerTokenAuthentication(accessToken)
       .sendForm(requestBody);

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
@@ -53,7 +53,7 @@ public class KeycloakAuthorizationFilter implements IngressRequestFilter, CacheI
   private final Cache<String, JsonWebToken> authTokenCache;
 
   /**
-   * Evaluates if a user has access to a module endpoint by obtaining RPT token from Keycloak.
+   * Evaluates if a user has access to a module endpoint using Keycloak UMA authorization.
    *
    * @param routingContext {@link RoutingContext} object to analyze
    * @return succeeded {@link Future} if access is granted.

--- a/src/main/java/org/folio/sidecar/utils/TokenRequestHelper.java
+++ b/src/main/java/org/folio/sidecar/utils/TokenRequestHelper.java
@@ -12,6 +12,7 @@ public class TokenRequestHelper {
   public static final String PASSWORD_GRANT_TYPE = "password";
   public static final String RPT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket";
   public static final String IMPERSONATION_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+  public static final String DECISION_RESPONSE_MODE = "decision";
 
   private static final String GRANT_TYPE_FORM_FIELD = "grant_type";
   private static final String CLIENT_ID_FORM_FIELD = "client_id";
@@ -20,6 +21,7 @@ public class TokenRequestHelper {
   private static final String PASSWORD_FORM_FIELD = "password";
   private static final String PERMISSION_FORM_FIELD = "permission";
   private static final String AUDIENCE_FORM_FIELD = "audience";
+  private static final String RESPONSE_MODE_FORM_FIELD = "response_mode";
   private static final String REFRESH_TOKEN_FORM_FIELD = "refresh_token";
   private static final String REQUESTED_SUBJECT_FORM_FIELD = "requested_subject";
   private static final String TOKEN = "token";
@@ -40,11 +42,12 @@ public class TokenRequestHelper {
       .set(CLIENT_SECRET_FORM_FIELD, client.getClientSecret());
   }
 
-  public static MultiMap prepareRptRequestBody(String clientId, String permission) {
+  public static MultiMap prepareUmaDecisionRequestBody(String clientId, String permission) {
     return MultiMap.caseInsensitiveMultiMap()
       .set(GRANT_TYPE_FORM_FIELD, RPT_GRANT_TYPE)
       .set(PERMISSION_FORM_FIELD, permission)
-      .set(AUDIENCE_FORM_FIELD, clientId);
+      .set(AUDIENCE_FORM_FIELD, clientId)
+      .set(RESPONSE_MODE_FORM_FIELD, DECISION_RESPONSE_MODE);
   }
 
   public static MultiMap prepareRefreshRequestBody(ClientCredentials client, String refreshToken) {

--- a/src/test/java/org/folio/sidecar/integration/keycloak/KeycloakClientTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/KeycloakClientTest.java
@@ -3,6 +3,7 @@ package org.folio.sidecar.integration.keycloak;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.sidecar.support.TestConstants.TENANT_NAME;
 import static org.folio.sidecar.utils.TokenRequestHelper.CLIENT_CREDENTIALS_GRANT_TYPE;
+import static org.folio.sidecar.utils.TokenRequestHelper.DECISION_RESPONSE_MODE;
 import static org.folio.sidecar.utils.TokenRequestHelper.IMPERSONATION_GRANT_TYPE;
 import static org.folio.sidecar.utils.TokenRequestHelper.RPT_GRANT_TYPE;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -86,10 +87,11 @@ class KeycloakClientTest {
     client.evaluatePermissions(TENANT_NAME, TEST_PERMISSION, TEST_TOKEN);
 
     var capturedRequestBody = bodyCaptor.getValue();
-    assertThat(capturedRequestBody).hasSize(3);
+    assertThat(capturedRequestBody).hasSize(4);
     assertThat(capturedRequestBody.get("grant_type")).isEqualTo(RPT_GRANT_TYPE);
     assertThat(capturedRequestBody.get("audience")).isEqualTo(TENANT_NAME + "-application");
     assertThat(capturedRequestBody.get("permission")).isEqualTo(TEST_PERMISSION);
+    assertThat(capturedRequestBody.get("response_mode")).isEqualTo(DECISION_RESPONSE_MODE);
 
     assertThat(uriCaptor.getValue()).isEqualTo(
       KEYCLOAK_URL + "/realms/" + TENANT_NAME + "/protocol/openid-connect/token");

--- a/src/test/java/org/folio/sidecar/utils/TokenRequestHelperTest.java
+++ b/src/test/java/org/folio/sidecar/utils/TokenRequestHelperTest.java
@@ -5,9 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.folio.sidecar.integration.cred.model.UserCredentials;
 import org.folio.sidecar.support.TestConstants;
-import org.junit.jupiter.api.Assertions;
+import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
 
+@UnitTest
 class TokenRequestHelperTest {
 
   private static final UserCredentials TEST_USER = UserCredentials.of("test", "testpwd");
@@ -17,9 +18,9 @@ class TokenRequestHelperTest {
     var actual = TokenRequestHelper.preparePasswordRequestBody(TestConstants.LOGIN_CLIENT_CREDENTIALS, TEST_USER);
 
     assertThat(actual).hasSize(5);
-    Assertions.assertEquals(TokenRequestHelper.PASSWORD_GRANT_TYPE, actual.get("grant_type"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
+    assertEquals(TokenRequestHelper.PASSWORD_GRANT_TYPE, actual.get("grant_type"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
     assertEquals("test", actual.get("username"));
     assertEquals("testpwd", actual.get("password"));
   }
@@ -29,20 +30,23 @@ class TokenRequestHelperTest {
     var actual = TokenRequestHelper.prepareClientRequestBody(TestConstants.LOGIN_CLIENT_CREDENTIALS);
 
     assertThat(actual).hasSize(3);
-    Assertions.assertEquals(TokenRequestHelper.CLIENT_CREDENTIALS_GRANT_TYPE, actual.get("grant_type"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
+    assertEquals(TokenRequestHelper.CLIENT_CREDENTIALS_GRANT_TYPE, actual.get("grant_type"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
   }
 
   @Test
-  void prepareRptRequestBody_positive() {
-    var actual =
-      TokenRequestHelper.prepareRptRequestBody(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), "/foo/bar#GET");
+  void prepareUmaDecisionRequestBody_positive() {
+    var actual = TokenRequestHelper.prepareUmaDecisionRequestBody(
+      TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(),
+      "/foo/bar#GET"
+    );
 
-    assertThat(actual).hasSize(3);
-    Assertions.assertEquals(TokenRequestHelper.RPT_GRANT_TYPE, actual.get("grant_type"));
+    assertThat(actual).hasSize(4);
+    assertEquals(TokenRequestHelper.RPT_GRANT_TYPE, actual.get("grant_type"));
     assertEquals("/foo/bar#GET", actual.get("permission"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("audience"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("audience"));
+    assertEquals(TokenRequestHelper.DECISION_RESPONSE_MODE, actual.get("response_mode"));
   }
 
   @Test
@@ -51,8 +55,8 @@ class TokenRequestHelperTest {
 
     assertThat(actual).hasSize(4);
     assertEquals("refresh_token", actual.get("grant_type"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
-    Assertions.assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientId(), actual.get("client_id"));
+    assertEquals(TestConstants.LOGIN_CLIENT_CREDENTIALS.getClientSecret(), actual.get("client_secret"));
     assertEquals("refreshtoken", actual.get("refresh_token"));
   }
 }

--- a/src/test/resources/mappings/keycloak/evaluate-permissions-forbidden.json
+++ b/src/test/resources/mappings/keycloak/evaluate-permissions-forbidden.json
@@ -14,6 +14,9 @@
             "contains": "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket"
           },
           {
+            "contains": "response_mode=decision"
+          },
+          {
             "contains": "permission=%2Ffoo%2Fxyz%23DELETE"
           }
         ]

--- a/src/test/resources/mappings/keycloak/evaluate-permissions-kc-400.json
+++ b/src/test/resources/mappings/keycloak/evaluate-permissions-kc-400.json
@@ -14,6 +14,9 @@
             "contains": "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket"
           },
           {
+            "contains": "response_mode=decision"
+          },
+          {
             "contains": "permission=%2Ffoo%2Fxyz%23PATCH"
           }
         ]

--- a/src/test/resources/mappings/keycloak/evaluate-permissions-kc-500.json
+++ b/src/test/resources/mappings/keycloak/evaluate-permissions-kc-500.json
@@ -14,6 +14,9 @@
             "contains": "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket"
           },
           {
+            "contains": "response_mode=decision"
+          },
+          {
             "contains": "permission=%2Ffoo%2Fxyz%23PUT"
           }
         ]

--- a/src/test/resources/mappings/keycloak/evaluate-permissions-unauthorized.json
+++ b/src/test/resources/mappings/keycloak/evaluate-permissions-unauthorized.json
@@ -14,6 +14,9 @@
             "contains": "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket"
           },
           {
+            "contains": "response_mode=decision"
+          },
+          {
             "contains": "permission=%2Ffoo%2Fxyz%23POST"
           }
         ]

--- a/src/test/resources/mappings/keycloak/evaluate-permissions.json
+++ b/src/test/resources/mappings/keycloak/evaluate-permissions.json
@@ -14,6 +14,9 @@
             "contains": "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket"
           },
           {
+            "contains": "response_mode=decision"
+          },
+          {
             "doesNotContain": "permission=%2Ffoo%2Fxyz%23DELETE"
           },
           {
@@ -36,14 +39,7 @@
           "Content-Type": "application/json"
         },
         "jsonBody": {
-          "access_token": "dGVzdC1hY2Nlc3MtdG9rZW4=",
-          "expires_in": 1800,
-          "refresh_expires_in": 1800,
-          "refresh_token": "dGVzdC1yZWZyZXNoLXRva2Vu",
-          "token_type": "Bearer",
-          "not-before-policy": 0,
-          "session_state": "19d1caf3-d604-4556-ba33-000bf4de176c",
-          "scope": "email profile"
+          "result": true
         }
       }
     }


### PR DESCRIPTION
### **Purpose**
Changes for [MODSIDECAR-182](https://folio-org.atlassian.net/browse/MODSIDECAR-182)

### **Approach**
- Adds response_mode=decision to request so Keycloak returns a lightweight authorization decision instead of a full RPT token. 
- The response HTTP status codes remain the same, so sidecar’s allow/deny behavior is unchanged.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
