### PR TITLE
(docs) update native build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ```shell script
 mvn install -Pnative -DskipTests \
   -Dquarkus.native.container-build=true \
-  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25
 ```
+
+The native builder image is the containerized Mandrel/GraalVM toolchain used by Quarkus to run `native-image`.
+It is independent of the application Java source/target version.
+Keep this image aligned with the Quarkus version and check the Quarkus Native Image guide or release notes for the supported Mandrel/GraalVM builder line.
 
 You can then execute your native executable with: `./target/folio-module-sidecar-1.0.0-SNAPSHOT.jar`
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ native (no JVM) mode. Before building the container image run:
 ```shell
 mvn install -Pnative -DskipTests \
   -Dquarkus.native.container-build=true \
-  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25
 ```
 
 Then, build the image with:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ native (no JVM) mode. Before building the container image run:
 ```shell
 mvn install -Pnative -DskipTests \
   -Dquarkus.native.container-build=true \
-  -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25
+  -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25
 ```
 
 Then, build the image with:
@@ -153,7 +153,7 @@ docker build -f docker/Dockerfile.native-micro -t folio-module-sidecar-native .
 Then run the container using:
 
 ```shell
-docker run -i --rm -p 8080:8080 quarkus/sidecar
+docker run -i --rm -p 8080:8080 folio-module-sidecar-native
 ```
 ### Building FIPS compatible image
 
@@ -168,7 +168,7 @@ docker build -f docker/Dockerfile.fips -t {{image-tag}}:{{image-version}}
 #### Using Docker
 
 To build a native executable in a container using a Linux image
-(e.g. quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 with size 1.29Gb) with the required build tools,
+(e.g. quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25 with size 1.29Gb) with the required build tools,
 use the following command:
 
 ```

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8081:8081 folio-module-sidecar-native
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 WORKDIR /work/
 RUN chown 1001 /work \


### PR DESCRIPTION
### **Purpose**
The current version of Quarkus doesn't support native build via JDK21, should be changed to JDK25 (the only builder image).
### **Approach**
- image builder for native sidecar `jdk21` -> `jdk25`
---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
