### PR TITLE
MODSIDECAR-198 - Support wildcard permissionsRequired ("*")

### DIFF
--- a/.ai-run/guides/project.md
+++ b/.ai-run/guides/project.md
@@ -1,0 +1,41 @@
+# Project Context
+
+## Project Identity
+
+| Field | Value | Source |
+|---|---|---|
+| Project name | folio-module-sidecar | pom.xml:6-8 |
+| Repository/package | org.folio:folio-module-sidecar | pom.xml:5-7 |
+| Project code/key | MODSIDECAR | branch `MODSIDECAR-198`, commit `1d32d20` (MODSIDECAR-182) |
+
+## Work Item Tracker
+
+| Field | Value |
+|---|---|
+| Provider | Jira (folio-org.atlassian.net) |
+| Key/prefix | MODSIDECAR |
+
+> Adapter configuration belongs exclusively in `## Ticket Adapter`. Do not duplicate adapter status or instructions in the Work Item Tracker table.
+
+## Ticket Adapter
+
+**Status**: configured
+**Adapter**: Atlassian MCP server (`mcp__atlassian-mcp__*` tools; resolve `cloudId` once via `mcp__atlassian-mcp__getAccessibleAtlassianResources`)
+**Lookup**: `mcp__atlassian-mcp__getJiraIssue` with `{cloudId, issueIdOrKey}` returns summary, description, status, and links; use `mcp__atlassian-mcp__searchJiraIssuesUsingJql` for queries
+**Create**: `mcp__atlassian-mcp__createJiraIssue` with `{cloudId, projectKey: "MODSIDECAR", issueTypeName, summary, description}` passing the complete payload
+**Output**: Jira issue key (e.g. `MODSIDECAR-198`) and browse URL `https://folio-org.atlassian.net/browse/<key>`
+
+## Source Control And Review
+
+| Field | Value |
+|---|---|
+| Provider | GitHub |
+| Repository remote | git@github.com:folio-org/folio-module-sidecar.git |
+| Default target branch | master |
+| Review artifact type | PR |
+
+## MR Adapter
+
+**Status**: configured
+**Adapter**: `gh` CLI (`gh pr create --base master`)
+**Instructions**: Open the PR against `master`. PR title follows the commit convention (`<TICKET> - <Summary>`). PRs are squash-merged; the squash subject carries the `(#<pr-number>)` suffix automatically on merge.

--- a/.ai-run/guides/quality-gates.md
+++ b/.ai-run/guides/quality-gates.md
@@ -1,0 +1,63 @@
+# Quality Gates
+
+Maven (Java 21, Quarkus 3.x) gates, ordered fastest-to-slowest. Sourced from
+`AGENTS.md`, `pom.xml`, and `.github/workflows/maven.yml`. Run the cheap gates
+locally before pushing; CI (`folio-org/.github` reusable Maven workflow) runs the
+full build, SonarCloud scan, and Docker build.
+
+### Checkstyle
+
+Enforces the FOLIO style rules (external `folio-java-checkstyle` artifact) plus a
+**23-line max method length** in production code. Bound to the `process-classes`
+phase during a normal build; can be run standalone.
+
+- **Run**: `mvn checkstyle:check`
+- **Pass**: `BUILD SUCCESS`, no violations reported.
+- **Fail**: `BUILD FAILURE` with `[ERROR] ... Checkstyle` lines naming file, line,
+  and rule (e.g. method longer than 23 lines, import order, line length). Any
+  warning fails the build — including test sources.
+- **Skip if**: never skip for production code changes; the 23-line limit applies
+  to `src/main/java` only (suppressed for `src/test/java`).
+
+### Unit tests
+
+JUnit 5 + Mockito, no Quarkus context (`@UnitTest`).
+
+- **Run**: `mvn test -Dgroups=unit`
+- **Single test**: `mvn test -Dgroups=unit -Dtest="ClassName#method"`
+- **Pass**: `BUILD SUCCESS`, `Tests run: N, Failures: 0, Errors: 0`.
+- **Fail**: `BUILD FAILURE`; failing test class/method and assertion shown in the
+  surefire output and `target/surefire-reports/`.
+
+### Integration tests
+
+`@IntegrationTest` (`@QuarkusTest`) with WireMock and in-memory Kafka.
+
+- **Run**: `mvn verify -Dgroups=integration`
+- **Pass**: `BUILD SUCCESS`, failsafe reports green.
+- **Fail**: `BUILD FAILURE`; see `target/failsafe-reports/`. Slower — boots a
+  Quarkus test context per class.
+- **Skip if**: the change touches only unit-tested logic with no
+  filter/routing/integration surface; note the skip in the QA report.
+
+### Coverage
+
+JaCoCo aggregate (unit + integration), 80% instruction minimum.
+
+- **Run**: `mvn verify -Pcoverage`
+- **Pass**: build completes; aggregate instruction coverage ≥ 80%
+  (`target/site/jacoco-aggregate/`). `haltOnFailure` is false, so it reports
+  rather than fails the local build, but keep new code covered.
+- **Fail**: coverage check logs the covered ratio below 80%; SonarCloud enforces
+  the gate in CI.
+
+### Full build
+
+Compile + checkstyle + tests + uber-jar packaging — the definitive local gate.
+
+- **Run**: `mvn clean install`
+- **Skip tests** (compile/package only): `mvn clean install -DskipTests`
+- **FIPS build**: `mvn clean -Pfips install`
+- **Pass**: `BUILD SUCCESS`; runnable `target/*-runner.jar` produced.
+- **Fail**: `BUILD FAILURE`; the first failing phase (compile, checkstyle, or
+  test) names the cause.

--- a/.ai-run/guides/standards/git-workflow.md
+++ b/.ai-run/guides/standards/git-workflow.md
@@ -1,0 +1,64 @@
+# Git Workflow
+
+Conventions derived from the repository's commit and branch history
+(`git log --oneline`, `git branch -a`). Default target branch: `master`.
+
+## Branch Naming Convention
+
+Feature work uses the **Jira ticket key verbatim** as the branch name, optionally
+prefixed with the author's handle:
+
+- `MODSIDECAR-198` — ticket key only (current branch, dominant pattern)
+- `pjacob/MODSIDECAR-194` — `<author>/<TICKET-KEY>`
+
+Non-ticket or thematic work uses a `feature/<kebab-description>` form:
+
+- `feature/multi-app-bootstrap-routing`
+
+Always branch from an up-to-date `master`. One ticket → one branch.
+
+## Commit Message Format
+
+Two accepted styles coexist:
+
+1. **Ticket-prefixed** (human feature work) — `MODSIDECAR-<NNN> - <Summary>` or
+   `MODSIDECAR-<NNN>: <Summary>`:
+   - `MODSIDECAR-182 - Migrate UMA Permission Checks to Response Mode Decision`
+   - `MODSIDECAR-192: Adjust Keycloak error handling`
+2. **Conventional Commits** (automation, deps, docs) — `<type>(<scope>): <summary>`:
+   - `fix(deps): bump the prod-deps group ...`
+   - `chore(deps-dev): bump the dev-deps group ...`
+   - `docs: optimize AGENTS.md for conciseness`
+   - `feat(logging): set minimum log level for sidecar to TRACE`
+
+For SDLC Factory work in this repo, prefer the **ticket-prefixed** form
+(`MODSIDECAR-<NNN> - <Summary>`) so the change is traceable to its Jira ticket.
+The `(#<pr-number>)` suffix is appended automatically by GitHub on squash-merge —
+do not add it manually.
+
+## Merge Strategy
+
+**Squash merge** via GitHub Pull Request. The history is linear: every mainline
+commit corresponds to one squashed PR with a `(#NNN)` suffix and there are no
+merge commits (`git log --merges` is empty). Rationale: one logical change = one
+mainline commit, keeping `master` bisectable and readable.
+
+## Anti-Patterns
+
+| Bad | Good |
+|---|---|
+| `fixed stuff` | `MODSIDECAR-198 - Add desired-permissions header to egress request` |
+| Branch `my-fix` | Branch `MODSIDECAR-198` |
+| Committing directly to `master` | Open a PR from a ticket branch into `master` |
+| Adding `(#123)` to a local commit by hand | Let GitHub add the PR-number suffix on squash-merge |
+| Mixing two tickets in one branch | One ticket → one branch → one squashed PR |
+
+## Troubleshooting
+
+- **Wrong base / stale branch**: `git fetch origin && git rebase origin/master`
+  (squash workflow keeps history linear; rebase rather than merge `master` in).
+- **Branch already exists remotely with the same ticket key**: coordinate with the
+  author (e.g. an existing `pjacob/MODSIDECAR-194`); prefix your handle to
+  disambiguate.
+- **Accidental commit on `master`**: create the ticket branch at HEAD
+  (`git switch -c MODSIDECAR-<NNN>`), then reset `master` to `origin/master`.

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ temp/
 .codemie/
 .agents/
 CLAUDE.md
+
+# AI
+.ai-run/sdlc-factory/
+.ai-run/runs/
+.agents/memory/sdlc/daily/
+docs/superpowers/runs/
+docs/superpowers/tasks/*/.state.json
+.claude/settings.local.json

--- a/docs/superpowers/plans/2026-06-26-modsidecar-198-wildcard-permissions.md
+++ b/docs/superpowers/plans/2026-06-26-modsidecar-198-wildcard-permissions.md
@@ -1,0 +1,467 @@
+# MODSIDECAR-198 Wildcard `permissionsRequired` Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the sidecar treat `permissionsRequired: ["*"]` as "valid token required, no named permission" while keeping `permissionsRequired: []` truly public.
+
+**Architecture:** Introduce three intention-revealing predicates in `RoutingUtils` (`isTrulyPublic`, `isWildcardPermissionRequired`, `requiresNoNamedPermission`) and point each Keycloak ingress filter at the precise one. Only the authorization filter changes behavior (skip RPT for wildcard); the JWT and tenant filters switch to `isTrulyPublic`, which is byte-for-byte equivalent to the old `hasNoPermissionsRequired` and keeps requiring token + tenant for `["*"]`.
+
+**Tech Stack:** Java 21, Quarkus 3.36, Vert.x Web `RoutingContext`, JUnit 5 + Mockito + AssertJ.
+
+## Global Constraints
+
+- Java 21; production methods ≤ 23 lines (checkstyle `process-classes`, fails on any warning incl. tests).
+- Never use lenient Mockito; verify only unmocked interactions; prefer helper methods over blanket `@BeforeEach` stubbing.
+- Test naming: `methodName_positive/negative_description`.
+- Wildcard convention is the **exact singleton** `["*"]` only; mixed lists like `["*","x"]` are NOT wildcard (AC6).
+- Commit message format: `MODSIDECAR-198 - <summary>`.
+- Run unit tests with: `mvn test -Dgroups=unit -Dtest="<Class>"`. Checkstyle: `mvn checkstyle:check`.
+
+---
+
+### Task 1: `RoutingUtils` permission predicates
+
+**Files:**
+- Modify: `src/main/java/org/folio/sidecar/utils/RoutingUtils.java` (around line 179, `hasNoPermissionsRequired`)
+- Test: `src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java`
+
+**Interfaces:**
+- Consumes: `getScRoutingEntry(rc)` → `ScRoutingEntry`; `ScRoutingEntry.getRoutingEntry()` → `ModuleBootstrapEndpoint`; `ModuleBootstrapEndpoint.getPermissionsRequired()` → `List<String>` (nullable); `CollectionUtils.isEmpty(Collection)`.
+- Produces: `public static final String WILDCARD_PERMISSION = "*"`; `boolean isTrulyPublic(RoutingContext)`; `boolean isWildcardPermissionRequired(RoutingContext)`; `boolean requiresNoNamedPermission(RoutingContext)`. (`hasNoPermissionsRequired` temporarily delegates to `isTrulyPublic`; removed in Task 4.)
+
+**Test-first:** yes — the three new helpers do not exist, so the new tests fail to compile/run until they are added.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `RoutingUtilsTest` (new imports: `java.util.List`, `org.folio.sidecar.integration.am.model.ModuleBootstrapEndpoint`, `org.folio.sidecar.model.ScRoutingEntry`):
+
+```java
+  @Test
+  void isTrulyPublic_positive_emptyPermissions() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of()))).isTrue();
+  }
+
+  @Test
+  void isTrulyPublic_positive_nullPermissions() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(null))).isTrue();
+  }
+
+  @Test
+  void isTrulyPublic_negative_namedPermission() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void isTrulyPublic_negative_wildcard() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of("*")))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_positive_singletonWildcard() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("*")))).isTrue();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_mixedList() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("*", "foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_emptyList() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of()))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_namedPermission() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void requiresNoNamedPermission_positive_trulyPublic() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of()))).isTrue();
+  }
+
+  @Test
+  void requiresNoNamedPermission_positive_wildcard() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("*")))).isTrue();
+  }
+
+  @Test
+  void requiresNoNamedPermission_negative_namedPermission() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void requiresNoNamedPermission_negative_mixedList() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("*", "foo.item.get")))).isFalse();
+  }
+
+  private static RoutingContext rcWithPermissions(List<String> permissionsRequired) {
+    var endpoint = new ModuleBootstrapEndpoint("/foo/items", "GET");
+    endpoint.setPermissionsRequired(permissionsRequired);
+    var entry = ScRoutingEntry.of("mod-foo-1.0", "http://mod-foo", "mod-foo-api-1.0", endpoint);
+    var rc = mock(RoutingContext.class);
+    when(rc.get(RoutingUtils.SC_ROUTING_ENTRY_KEY)).thenReturn(entry);
+    return rc;
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mvn test -Dgroups=unit -Dtest="RoutingUtilsTest"`
+Expected: FAIL — compilation error, `isTrulyPublic`/`isWildcardPermissionRequired`/`requiresNoNamedPermission` not found.
+
+- [ ] **Step 3: Add the predicates to `RoutingUtils`**
+
+Add the constant near the other constants (after line 48):
+
+```java
+  public static final String WILDCARD_PERMISSION = "*";
+```
+
+Replace the existing `hasNoPermissionsRequired` method (line 179) with:
+
+```java
+  /**
+   * Truly public endpoint: no token required (e.g. forgotten-password). {@code permissionsRequired} is null/empty.
+   */
+  public static boolean isTrulyPublic(RoutingContext rc) {
+    var endpoint = getScRoutingEntry(rc).getRoutingEntry();
+    return isEmpty(endpoint.getPermissionsRequired());
+  }
+
+  /**
+   * Wildcard-authenticated endpoint: a valid token is required but no named permission. The convention is the
+   * exact singleton {@code ["*"]}; a mixed list such as {@code ["*", "perm"]} is NOT wildcard.
+   */
+  public static boolean isWildcardPermissionRequired(RoutingContext rc) {
+    var permissionsRequired = getScRoutingEntry(rc).getRoutingEntry().getPermissionsRequired();
+    return permissionsRequired != null && permissionsRequired.size() == 1
+      && WILDCARD_PERMISSION.equals(permissionsRequired.get(0));
+  }
+
+  /**
+   * No specific named permission to evaluate: either truly public or wildcard-authenticated.
+   */
+  public static boolean requiresNoNamedPermission(RoutingContext rc) {
+    return isTrulyPublic(rc) || isWildcardPermissionRequired(rc);
+  }
+
+  /**
+   * @deprecated transitional alias for {@link #isTrulyPublic(RoutingContext)}; removed once all filters migrate.
+   */
+  @Deprecated
+  public static boolean hasNoPermissionsRequired(RoutingContext rc) {
+    return isTrulyPublic(rc);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn test -Dgroups=unit -Dtest="RoutingUtilsTest"`
+Expected: PASS (all new + existing tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/org/folio/sidecar/utils/RoutingUtils.java src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+git commit -m "MODSIDECAR-198 - Add truly-public/wildcard permission predicates to RoutingUtils"
+```
+
+---
+
+### Task 2: Authorization filter skips RPT for wildcard (behavior change)
+
+**Files:**
+- Modify: `src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java` (import line 17; `shouldSkip` line 80)
+- Test: `src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilterTest.java`
+
+**Interfaces:**
+- Consumes: `RoutingUtils.requiresNoNamedPermission(RoutingContext)` from Task 1.
+- Produces: none (internal filter change).
+
+**Test-first:** yes — failing test: `shouldSkip` for a `["*"]` endpoint currently returns `false` (RPT runs); after the change it must return `true`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `KeycloakAuthorizationFilterTest` (uses existing `scRoutingEntry(...)` from `AbstractFilterTest`, `RETURNS_DEEP_STUBS`, `SC_ROUTING_ENTRY_KEY`):
+
+```java
+  @Test
+  void shouldSkip_positive_wildcardPermission() {
+    var routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
+    when(routingContext.get(SC_ROUTING_ENTRY_KEY)).thenReturn(scRoutingEntry("not-system", "*"));
+
+    var result = keycloakAuthorizationFilter.shouldSkip(routingContext);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldSkip_negative_wildcardWithNamedPermission() {
+    var routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
+    when(routingContext.get(SC_ROUTING_ENTRY_KEY)).thenReturn(scRoutingEntry("not-system", "*", "foo.item.get"));
+
+    var result = keycloakAuthorizationFilter.shouldSkip(routingContext);
+
+    assertThat(result).isFalse();
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mvn test -Dgroups=unit -Dtest="KeycloakAuthorizationFilterTest"`
+Expected: FAIL — `shouldSkip_positive_wildcardPermission` expects `true` but gets `false` (RPT not yet skipped for wildcard).
+
+- [ ] **Step 3: Swap the predicate**
+
+In `KeycloakAuthorizationFilter.java`, change the static import (line 17):
+
+```java
+import static org.folio.sidecar.utils.RoutingUtils.requiresNoNamedPermission;
+```
+
+and `shouldSkip` (line 80):
+
+```java
+  @Override
+  public boolean shouldSkip(RoutingContext rc) {
+    return !isTimerRequest(rc) && (isSystemRequest(rc) || requiresNoNamedPermission(rc)) || isSelfRequest(rc);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn test -Dgroups=unit -Dtest="KeycloakAuthorizationFilterTest"`
+Expected: PASS (new wildcard tests + existing named/public/system/self/timer tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilterTest.java
+git commit -m "MODSIDECAR-198 - Skip Keycloak RPT evaluation for wildcard-authenticated endpoints"
+```
+
+---
+
+### Task 3: Tenant filter uses `isTrulyPublic`; lock wildcard tenant validation
+
+**Files:**
+- Modify: `src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilter.java` (import line 10; `shouldSkip` line 59)
+- Test: `src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilterTest.java`
+
+**Interfaces:**
+- Consumes: `RoutingUtils.isTrulyPublic(RoutingContext)` from Task 1.
+- Produces: none.
+
+**Test-first:** no — the production edit is a clarity rename (`isTrulyPublic` ≡ old `hasNoPermissionsRequired`); wildcard already validated tenant because `["*"]` is non-empty. The added tests are AC3/AC4 regression locks that pass before and after; they guard against future drift.
+
+- [ ] **Step 1: Swap the predicate**
+
+In `KeycloakTenantFilter.java`, change the static import (line 10):
+
+```java
+import static org.folio.sidecar.utils.RoutingUtils.isTrulyPublic;
+```
+
+and `shouldSkip` (line 59):
+
+```java
+  @Override
+  public boolean shouldSkip(RoutingContext rc) {
+    return !isTimerRequest(rc) && (isSystemRequest(rc) || isTrulyPublic(rc)) || isSelfRequest(rc);
+  }
+```
+
+- [ ] **Step 2: Add regression tests**
+
+Add to `KeycloakTenantFilterTest` (uses existing `routingContext(...)`, `scRoutingEntry(...)`, `keycloakIssuer(...)`, `TENANT_NAME`, `PARSED_TOKEN`, `SYSTEM_TOKEN`, `TENANT`):
+
+```java
+  @Test
+  void shouldSkip_negative_wildcardPermission() {
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {});
+    var actual = keycloakTenantFilter.shouldSkip(routingContext);
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void filter_positive_wildcardTenantMatches() {
+    var accessToken = mock(JsonWebToken.class);
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.get(RoutingUtils.SELF_REQUEST_KEY)).thenReturn(false);
+      when(rc.get(PARSED_TOKEN)).thenReturn(accessToken);
+      when(rc.get(SYSTEM_TOKEN)).thenReturn(null);
+      when(accessToken.getIssuer()).thenReturn(keycloakIssuer(TENANT_NAME));
+      when(rc.request().getHeader(TENANT)).thenReturn(TENANT_NAME);
+    });
+    when(sidecarProperties.isCrossTenantEnabled()).thenReturn(false);
+
+    var result = keycloakTenantFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isEqualTo(routingContext);
+  }
+
+  @Test
+  void filter_negative_wildcardTenantMismatch() {
+    var accessToken = mock(JsonWebToken.class);
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.get(RoutingUtils.SELF_REQUEST_KEY)).thenReturn(false);
+      when(rc.get(PARSED_TOKEN)).thenReturn(accessToken);
+      when(rc.get(SYSTEM_TOKEN)).thenReturn(null);
+      when(accessToken.getIssuer()).thenReturn(keycloakIssuer("test-tenant-a"));
+      when(rc.request().getHeader(TENANT)).thenReturn("test-tenant-b");
+    });
+    when(sidecarProperties.isCrossTenantEnabled()).thenReturn(false);
+
+    var result = keycloakTenantFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("X-Okapi-Tenant header is not the same as resolved tenant");
+  }
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `mvn test -Dgroups=unit -Dtest="KeycloakTenantFilterTest"`
+Expected: PASS (wildcard validation runs for `["*"]`; existing tests green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilter.java src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilterTest.java
+git commit -m "MODSIDECAR-198 - Use isTrulyPublic in tenant filter and cover wildcard tenant validation"
+```
+
+---
+
+### Task 4: JWT filter uses `isTrulyPublic`; lock wildcard token enforcement; remove dead alias
+
+**Files:**
+- Modify: `src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java` (import line 13; `handleFailedTokenParsing` line 125)
+- Modify: `src/main/java/org/folio/sidecar/utils/RoutingUtils.java` (remove the transitional `hasNoPermissionsRequired`)
+- Test: `src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java`
+
+**Interfaces:**
+- Consumes: `RoutingUtils.isTrulyPublic(RoutingContext)` from Task 1.
+- Produces: none. After this task `hasNoPermissionsRequired` no longer exists.
+
+**Test-first:** no — the JWT production edit is a clarity rename (`isTrulyPublic` ≡ old `hasNoPermissionsRequired`); `["*"]` already required a token because it is non-empty. Added tests are AC2/FR4 regression locks (green before and after). The alias removal is a safe dead-code deletion guarded by compilation + the full suite.
+
+- [ ] **Step 1: Swap the predicate**
+
+In `KeycloakJwtFilter.java`, change the static import (line 13):
+
+```java
+import static org.folio.sidecar.utils.RoutingUtils.isTrulyPublic;
+```
+
+and in `handleFailedTokenParsing` (line 125) replace `hasNoPermissionsRequired(rc)` with `isTrulyPublic(rc)`:
+
+```java
+    if (isTrulyPublic(rc) && !Objects.equals(FAILED_TO_PARSE_JWT_ERROR_MSG, error.getMessage())
+      || isSelfRequest(rc) && !hasToken(rc)
+      // If system token is present, then we should not fail the request
+      || getParsedSystemToken(rc).isPresent()) {
+      return succeededFuture(rc);
+    }
+```
+
+- [ ] **Step 2: Add regression tests**
+
+Add to `KeycloakJwtFilterTest` (uses existing `routingContext(...)`, `scRoutingEntry(...)`, `headers(...)`, `request`, `AUTH_TOKEN`, `TOKEN`, `asyncJsonWebTokenParser`, `ParseException`):
+
+```java
+  // AC1 positive path (truly public): [] + missing token must be ALLOWED.
+  // Pairs with filter_negative_wildcardMissingToken below to demonstrate the [] vs ["*"] difference (FR10).
+  @Test
+  void filter_positive_publicMissingToken() {
+    var requestHeaders = headers(Collections.emptyMap());
+    var routingContext = routingContext(scRoutingEntry("not-system"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isEqualTo(routingContext);
+  }
+
+  @Test
+  void filter_negative_wildcardMissingToken() {
+    var requestHeaders = headers(Collections.emptyMap());
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("Failed to find JWT in request");
+  }
+
+  @Test
+  void filter_negative_wildcardInvalidToken() {
+    var requestHeaders = headers(Map.of(TOKEN, AUTH_TOKEN));
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    when(asyncJsonWebTokenParser.parseAsync(AUTH_TOKEN)).thenReturn(Future.failedFuture(
+      new UnauthorizedException("Failed to parse JWT", new ParseException("Failed to parse JWT, invalid offset"))));
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("Failed to parse JWT");
+  }
+```
+
+- [ ] **Step 3: Remove the transitional alias**
+
+In `RoutingUtils.java`, delete the `@Deprecated hasNoPermissionsRequired(...)` method added in Task 1. Confirm no references remain:
+
+Run: `grep -rn "hasNoPermissionsRequired" src/`
+Expected: no matches.
+
+- [ ] **Step 4: Run the full unit suite + checkstyle**
+
+Run: `mvn test -Dgroups=unit`
+Expected: PASS (whole suite green).
+
+Run: `mvn checkstyle:check`
+Expected: PASS (no warnings; all new methods ≤ 23 lines).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java src/main/java/org/folio/sidecar/utils/RoutingUtils.java src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
+git commit -m "MODSIDECAR-198 - Use isTrulyPublic in JWT filter and remove dead hasNoPermissionsRequired alias"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC1 (`[]` public) — Task 4 `filter_positive_publicMissingToken` explicitly locks `[]` + missing token → allowed (the truly-public failed-parse tolerance branch, which no pre-existing JWT test covered). `isTrulyPublic` == old predicate, so the rename is behavior-preserving; the new test is the regression lock. Paired with `filter_negative_wildcardMissingToken` it demonstrates the `[]` vs `["*"]` difference (FR10). ✓
+- AC2 (`["*"]` no token → 401) — Task 4 `filter_negative_wildcardMissingToken`. ✓
+- AC3 (`["*"]` valid token → parse+tenant run, RPT skipped) — Task 2 `shouldSkip_positive_wildcardPermission` + Task 3 `filter_positive_wildcardTenantMatches`. ✓
+- AC4 (`["*"]` tenant mismatch → reject) — Task 3 `filter_negative_wildcardTenantMismatch`. ✓
+- AC5 (named perms unchanged) — existing `shouldSkip_positive()` (named → false) + Task 2 `shouldSkip_negative_wildcardWithNamedPermission`. ✓
+- AC6 (`["*","x"]` not wildcard) — Task 1 `isWildcardPermissionRequired_negative_mixedList` + Task 2 `shouldSkip_negative_wildcardWithNamedPermission`. ✓
+- FR3 (clear helpers) — Task 1. FR4 (missing/invalid token) — Task 4 both tests. FR7 (skip RPT) — Task 2. FR8 (system/timer/self unchanged) — guards untouched; existing system/self/timer tests green. FR10 (tests for `[]` vs `["*"]` vs named) — covered across tasks.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** helper names (`isTrulyPublic`, `isWildcardPermissionRequired`, `requiresNoNamedPermission`, constant `WILDCARD_PERMISSION`) are used identically across Tasks 1–4. `ScRoutingEntry.of(String, String, String, ModuleBootstrapEndpoint)` and `setPermissionsRequired(List<String>)` match the real signatures.

--- a/docs/superpowers/specs/2026-06-26-modsidecar-198-wildcard-permissions-design.md
+++ b/docs/superpowers/specs/2026-06-26-modsidecar-198-wildcard-permissions-design.md
@@ -1,0 +1,122 @@
+# Design — MODSIDECAR-198: Wildcard `permissionsRequired` support
+
+**Date**: 2026-06-26
+**Ticket**: https://folio-org.atlassian.net/browse/MODSIDECAR-198 (Story, P2)
+**Run**: 20260626-1014-MODSIDECAR-198
+**Requirements**: `docs/superpowers/runs/20260626-1014-MODSIDECAR-198/requirements.md`
+
+## Problem
+
+The sidecar's ingress security filters key off a single predicate —
+`RoutingUtils.hasNoPermissionsRequired(rc)` = `isEmpty(permissionsRequired)` — to
+decide whether an endpoint is protected. This collapses two genuinely different
+intents into one:
+
+- **Truly public** (`permissionsRequired: []` or missing) — no token required
+  (e.g. forgotten-password).
+- **Authenticated, no named permission** — caller identity from a JWT is
+  required, but no specific permission (e.g. `GET /users-keycloak/_self`).
+
+Module descriptors need a way to express the second intent. The agreed
+convention (from the MODSIDECAR-191 spike) is the exact singleton
+`permissionsRequired: ["*"]`.
+
+## Current behavior (verified in code)
+
+For the three Keycloak ingress filters, with `permissionsRequired = ["*"]`
+(a **non-empty** list, so `hasNoPermissionsRequired` returns `false` today):
+
+| Filter (order) | Predicate today | Effect for `["*"]` today | Desired |
+|---|---|---|---|
+| `KeycloakJwtFilter` (120) | `hasNoPermissionsRequired` gates failure-tolerance | Token **required** (missing/invalid ⇒ 401) | ✅ already correct |
+| `KeycloakTenantFilter` (130) | skips when `hasNoPermissionsRequired` | Tenant validation **runs** | ✅ already correct |
+| `KeycloakAuthorizationFilter` (160) | skips when `hasNoPermissionsRequired` | RPT evaluation **runs** ❌ | must **skip** |
+
+So the only behavioral gap is the authorization filter calling Keycloak RPT
+evaluation for a wildcard endpoint, where there is no named permission to
+evaluate. The JWT and tenant filters already behave correctly because `["*"]` is
+non-empty — but they rely on the *implicit* emptiness check, which is fragile.
+
+## Design decision — `RoutingUtils` helper API
+
+The fix needs the filters to distinguish three states explicitly. Two options:
+
+**Option A (chosen): rename + add, point each filter at the precise helper.**
+- `isTrulyPublic(rc)` — replaces `hasNoPermissionsRequired`; `permissionsRequired` is null/empty.
+- `isWildcardPermissionRequired(rc)` — `permissionsRequired` is the exact singleton `["*"]`.
+- `requiresNoNamedPermission(rc)` — `isTrulyPublic(rc) || isWildcardPermissionRequired(rc)`.
+
+Filters:
+- `KeycloakJwtFilter` → `isTrulyPublic` (failure-tolerance only for truly-public; behavior unchanged, intent now explicit).
+- `KeycloakTenantFilter` → `isTrulyPublic` (skip only for truly-public; wildcard keeps validating tenant; behavior unchanged).
+- `KeycloakAuthorizationFilter` → `requiresNoNamedPermission` (**behavior change**: skip RPT for truly-public **and** wildcard).
+
+**Option B (rejected): keep `hasNoPermissionsRequired`, only add helpers.**
+Less churn, but leaves a misleadingly-named predicate (`hasNoPermissionsRequired`
+is ambiguous once `["*"]` exists — does "no permissions" include wildcard?). For
+security code, an ambiguous predicate invites future drift. The ticket also
+explicitly calls for updating all three filters and `RoutingUtils`.
+
+**Recommendation: Option A.** It is intention-revealing (Clean Code, FR3), makes
+each filter's contract explicit, and prevents the emptiness check from silently
+absorbing the wildcard case later. `hasNoPermissionsRequired` has exactly the
+semantics of `isTrulyPublic`, and is internal (only the three filters call it),
+so the rename is safe and confined.
+
+## Wildcard predicate (narrow, deterministic — NFR2, AC6)
+
+```java
+public static final String WILDCARD_PERMISSION = "*";
+
+public static boolean isWildcardPermissionRequired(RoutingContext rc) {
+  var perms = getScRoutingEntry(rc).getRoutingEntry().getPermissionsRequired();
+  return perms != null && perms.size() == 1 && WILDCARD_PERMISSION.equals(perms.get(0));
+}
+```
+
+Only an exact singleton `["*"]` qualifies. `["*", "x"]` (size 2) is a
+named-permission list and follows the normal path (AC6). `[]`/null is truly
+public (AC1).
+
+## Components & data flow
+
+No new classes, no schema change, no new config. The change is localized to:
+
+- `utils/RoutingUtils.java` — helper methods + `WILDCARD_PERMISSION` constant.
+- `integration/keycloak/filter/KeycloakJwtFilter.java` — swap predicate.
+- `integration/keycloak/filter/KeycloakTenantFilter.java` — swap predicate.
+- `integration/keycloak/filter/KeycloakAuthorizationFilter.java` — swap predicate to `requiresNoNamedPermission`.
+
+Request flow for `["*"]`: JWT(120) parses & requires token → Tenant(130)
+validates tenant claim vs `x-okapi-tenant` → Authorization(160) **skips** → forward
+to module. Missing token fails at JWT(120) with the existing
+`UnauthorizedException` (NFR3: identical to other protected endpoints).
+
+## Error handling
+
+Reuses existing exceptions/paths — `UnauthorizedException` for missing/invalid
+token (JWT filter) and tenant mismatch (tenant filter). No new error types.
+
+## Testing strategy (FR10)
+
+Unit tests only (matches the established per-filter unit-test pattern; no
+Keycloak/Quarkus context needed):
+
+- `RoutingUtilsTest`: `isTrulyPublic` (empty/null ⇒ true; non-empty ⇒ false);
+  `isWildcardPermissionRequired` (`["*"]` ⇒ true; `["*","x"]` ⇒ false; `[]`/named ⇒
+  false); `requiresNoNamedPermission` (truly-public ⇒ true, wildcard ⇒ true,
+  named ⇒ false).
+- `KeycloakAuthorizationFilterTest`: `shouldSkip` true for `["*"]`; false for
+  `["*","x"]` and named (AC3, AC5, AC6).
+- `KeycloakTenantFilterTest`: `shouldSkip` false for `["*"]` (validation runs);
+  filter rejects tenant mismatch for `["*"]` (AC3, AC4).
+- `KeycloakJwtFilterTest`: `["*"]` + missing token ⇒ rejected (AC2); `[]` +
+  missing token ⇒ allowed/unchanged (AC1).
+
+Existing tests for `[]` and named permissions must stay green (regression guard
+for AC1/AC5).
+
+## Out of scope
+
+Downstream module descriptors, `applications-poc-tools`,
+`mgr-tenant-entitlements`, and any descriptor schema changes.

--- a/docs/superpowers/work-items/MODSIDECAR-198.md
+++ b/docs/superpowers/work-items/MODSIDECAR-198.md
@@ -1,0 +1,33 @@
+# MODSIDECAR-198 — Implement wildcard permissionsRequired support
+
+**Provider**: Jira · **Key**: MODSIDECAR-198 · **Type**: Story · **Priority**: P2
+**URL**: https://folio-org.atlassian.net/browse/MODSIDECAR-198
+**Status**: Ready for review (SDLC run 20260626-1014-MODSIDECAR-198)
+**Branch**: MODSIDECAR-198 (4 code commits + 1 artifacts commit)
+
+## Summary
+
+Treat `permissionsRequired: ["*"]` as "valid token required, no named permission";
+keep `permissionsRequired: []` as truly public. Only the exact singleton `["*"]`
+counts as the wildcard convention.
+
+## Outcome
+
+- `RoutingUtils`: added `isTrulyPublic`, `isWildcardPermissionRequired`, `requiresNoNamedPermission`; removed the old `hasNoPermissionsRequired`.
+- `KeycloakAuthorizationFilter`: skips Keycloak RPT for wildcard endpoints (the one behavioral change).
+- `KeycloakTenantFilter` / `KeycloakJwtFilter`: switched to `isTrulyPublic` (explicit, behavior-preserving) so `["*"]` still requires a token and a validated tenant.
+- All 6 acceptance criteria covered by tests. 541 unit + 73 integration tests pass; checkstyle clean. Code review approved (3 lenses, high confidence). Actual complexity: S (14/36).
+
+## Linked Artifacts
+
+- docs/superpowers/specs/2026-06-26-modsidecar-198-wildcard-permissions-design.md
+- docs/superpowers/plans/2026-06-26-modsidecar-198-wildcard-permissions.md
+- docs/superpowers/runs/20260626-1014-MODSIDECAR-198/requirements.md
+- docs/superpowers/runs/20260626-1014-MODSIDECAR-198/qa-report.md
+- docs/superpowers/runs/20260626-1014-MODSIDECAR-198/code-review-final.json
+
+## History
+
+- 2026-06-26T08:14:13Z — work_item.created (placeholder from raw_input)
+- 2026-06-26T08:15:00Z — work_item.assigned — branch MODSIDECAR-198; requirements resolved from Jira
+- 2026-06-26T09:40:00Z — work_item.transitioned — Ready for review; implementation, review, and QA complete

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilter.java
@@ -14,10 +14,10 @@ import static org.folio.sidecar.utils.RoutingUtils.getParsedSystemToken;
 import static org.folio.sidecar.utils.RoutingUtils.getParsedToken;
 import static org.folio.sidecar.utils.RoutingUtils.getScRoutingEntry;
 import static org.folio.sidecar.utils.RoutingUtils.getTenant;
-import static org.folio.sidecar.utils.RoutingUtils.hasNoPermissionsRequired;
 import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isSystemRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isTimerRequest;
+import static org.folio.sidecar.utils.RoutingUtils.requiresNoNamedPermission;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import io.quarkus.security.ForbiddenException;
@@ -77,7 +77,7 @@ public class KeycloakAuthorizationFilter implements IngressRequestFilter, CacheI
 
   @Override
   public boolean shouldSkip(RoutingContext rc) {
-    return !isTimerRequest(rc) && (isSystemRequest(rc) || hasNoPermissionsRequired(rc)) || isSelfRequest(rc);
+    return !isTimerRequest(rc) && (isSystemRequest(rc) || requiresNoNamedPermission(rc)) || isSelfRequest(rc);
   }
 
   @Override

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilter.java
@@ -10,11 +10,11 @@ import static org.folio.sidecar.service.filter.IngressFilterOrder.KEYCLOAK_JWT;
 import static org.folio.sidecar.utils.JwtUtils.getUserIdClaim;
 import static org.folio.sidecar.utils.JwtUtils.trimTokenBearer;
 import static org.folio.sidecar.utils.RoutingUtils.getParsedSystemToken;
-import static org.folio.sidecar.utils.RoutingUtils.hasNoPermissionsRequired;
 import static org.folio.sidecar.utils.RoutingUtils.hasUserIdHeader;
 import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isSystemRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isTimerRequest;
+import static org.folio.sidecar.utils.RoutingUtils.isTrulyPublic;
 import static org.folio.sidecar.utils.RoutingUtils.putOriginTenant;
 import static org.folio.sidecar.utils.RoutingUtils.putParsedToken;
 import static org.folio.sidecar.utils.RoutingUtils.setUserIdHeader;
@@ -122,7 +122,7 @@ public class KeycloakJwtFilter implements IngressRequestFilter {
    * @return {@link Future} of {@link RoutingContext} object
    */
   private static Future<RoutingContext> handleFailedTokenParsing(RoutingContext rc, Throwable error) {
-    if (hasNoPermissionsRequired(rc) && !Objects.equals(FAILED_TO_PARSE_JWT_ERROR_MSG, error.getMessage())
+    if (isTrulyPublic(rc) && !Objects.equals(FAILED_TO_PARSE_JWT_ERROR_MSG, error.getMessage())
       || isSelfRequest(rc) && !hasToken(rc)
       // If system token is present, then we should not fail the request
       || getParsedSystemToken(rc).isPresent()) {

--- a/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilter.java
+++ b/src/main/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilter.java
@@ -7,10 +7,10 @@ import static org.folio.sidecar.service.filter.IngressFilterOrder.KEYCLOAK_TENAN
 import static org.folio.sidecar.utils.RoutingUtils.getParsedSystemToken;
 import static org.folio.sidecar.utils.RoutingUtils.getParsedToken;
 import static org.folio.sidecar.utils.RoutingUtils.getTenant;
-import static org.folio.sidecar.utils.RoutingUtils.hasNoPermissionsRequired;
 import static org.folio.sidecar.utils.RoutingUtils.isSelfRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isSystemRequest;
 import static org.folio.sidecar.utils.RoutingUtils.isTimerRequest;
+import static org.folio.sidecar.utils.RoutingUtils.isTrulyPublic;
 
 import io.quarkus.security.UnauthorizedException;
 import io.vertx.core.Future;
@@ -56,7 +56,7 @@ public class KeycloakTenantFilter implements IngressRequestFilter {
 
   @Override
   public boolean shouldSkip(RoutingContext rc) {
-    return !isTimerRequest(rc) && (isSystemRequest(rc) || hasNoPermissionsRequired(rc)) || isSelfRequest(rc);
+    return !isTimerRequest(rc) && (isSystemRequest(rc) || isTrulyPublic(rc)) || isSelfRequest(rc);
   }
 
   @Override

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -45,6 +45,11 @@ public class RoutingUtils {
   public static final String EGRESS_REQUEST_KEY = "egressRequest";
   public static final String ORIGIN_TENANT = "originTenant";
   public static final String PARSED_TOKEN = "parsedToken";
+
+  /**
+   * Wildcard permission convention: a valid token is required but no named permission is.
+   */
+  public static final String WILDCARD_PERMISSION = "*";
   private static final int URI_MAX_LENGTH = 512;
 
   /**
@@ -176,10 +181,39 @@ public class RoutingUtils {
     rc.put(EGRESS_REQUEST_KEY, true);
   }
 
-  public static boolean hasNoPermissionsRequired(RoutingContext rc) {
-    var scRoutingEntry = getScRoutingEntry(rc);
-    var endpoint = scRoutingEntry.getRoutingEntry();
+  /**
+   * Truly public endpoint: no token required (e.g. forgotten-password). {@code permissionsRequired} is null/empty.
+   */
+  public static boolean isTrulyPublic(RoutingContext rc) {
+    var endpoint = getScRoutingEntry(rc).getRoutingEntry();
     return isEmpty(endpoint.getPermissionsRequired());
+  }
+
+  /**
+   * Wildcard-authenticated endpoint: a valid token is required but no named permission. The convention is the exact
+   * singleton {@code ["*"]}; a mixed list such as {@code ["*", "perm"]} is NOT wildcard.
+   */
+  public static boolean isWildcardPermissionRequired(RoutingContext rc) {
+    var permissionsRequired = getScRoutingEntry(rc).getRoutingEntry().getPermissionsRequired();
+    return permissionsRequired != null && permissionsRequired.size() == 1
+      && WILDCARD_PERMISSION.equals(permissionsRequired.get(0));
+  }
+
+  /**
+   * No specific named permission to evaluate: either truly public or wildcard-authenticated.
+   */
+  public static boolean requiresNoNamedPermission(RoutingContext rc) {
+    return isTrulyPublic(rc) || isWildcardPermissionRequired(rc);
+  }
+
+  /**
+   * Transitional alias for {@link #isTrulyPublic(RoutingContext)}; removed once all filters migrate.
+   *
+   * @deprecated use {@link #isTrulyPublic(RoutingContext)} or {@link #requiresNoNamedPermission(RoutingContext)}
+   */
+  @Deprecated
+  public static boolean hasNoPermissionsRequired(RoutingContext rc) {
+    return isTrulyPublic(rc);
   }
 
   public static boolean isTenantInstallRequest(RoutingContext rc) {

--- a/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
+++ b/src/main/java/org/folio/sidecar/utils/RoutingUtils.java
@@ -206,16 +206,6 @@ public class RoutingUtils {
     return isTrulyPublic(rc) || isWildcardPermissionRequired(rc);
   }
 
-  /**
-   * Transitional alias for {@link #isTrulyPublic(RoutingContext)}; removed once all filters migrate.
-   *
-   * @deprecated use {@link #isTrulyPublic(RoutingContext)} or {@link #requiresNoNamedPermission(RoutingContext)}
-   */
-  @Deprecated
-  public static boolean hasNoPermissionsRequired(RoutingContext rc) {
-    return isTrulyPublic(rc);
-  }
-
   public static boolean isTenantInstallRequest(RoutingContext rc) {
     var scRoutingEntry = getScRoutingEntry(rc);
     return TENANT_INTERFACE.equals(scRoutingEntry.getInterfaceId());

--- a/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilterTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakAuthorizationFilterTest.java
@@ -352,6 +352,26 @@ class KeycloakAuthorizationFilterTest extends AbstractFilterTest {
   }
 
   @Test
+  void shouldSkip_positive_wildcardPermission() {
+    var routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
+    when(routingContext.get(SC_ROUTING_ENTRY_KEY)).thenReturn(scRoutingEntry("not-system", "*"));
+
+    var result = keycloakAuthorizationFilter.shouldSkip(routingContext);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldSkip_negative_wildcardWithNamedPermission() {
+    var routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
+    when(routingContext.get(SC_ROUTING_ENTRY_KEY)).thenReturn(scRoutingEntry("not-system", "*", "foo.item.get"));
+
+    var result = keycloakAuthorizationFilter.shouldSkip(routingContext);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
   void shouldSkip_selfRequest() {
     var routingContext = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
     when(routingContext.get(SC_ROUTING_ENTRY_KEY)).thenReturn(scRoutingEntry("not-system", REQUIRED_PERMISSION));

--- a/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakJwtFilterTest.java
@@ -255,6 +255,57 @@ class KeycloakJwtFilterTest extends AbstractFilterTest {
       .hasMessage("Failed to find JWT in request");
   }
 
+  // AC1 positive path (truly public): [] + missing token must be ALLOWED.
+  // Pairs with filter_negative_wildcardMissingToken to demonstrate the [] vs ["*"] difference (FR10).
+  @Test
+  void filter_positive_publicMissingToken() {
+    var requestHeaders = headers(Collections.emptyMap());
+    var routingContext = routingContext(scRoutingEntry("not-system"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isEqualTo(routingContext);
+  }
+
+  @Test
+  void filter_negative_wildcardMissingToken() {
+    var requestHeaders = headers(Collections.emptyMap());
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("Failed to find JWT in request");
+  }
+
+  @Test
+  void filter_negative_wildcardInvalidToken() {
+    var requestHeaders = headers(Map.of(TOKEN, AUTH_TOKEN));
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.request()).thenReturn(request);
+      when(request.headers()).thenReturn(requestHeaders);
+    });
+
+    when(asyncJsonWebTokenParser.parseAsync(AUTH_TOKEN)).thenReturn(Future.failedFuture(
+      new UnauthorizedException("Failed to parse JWT", new ParseException("Failed to parse JWT, invalid offset"))));
+
+    var result = keycloakJwtFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("Failed to parse JWT");
+  }
+
   @Test
   void filter_negative_tokenMismatch() {
     var token1 = "dG9rZW4tb25l";

--- a/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilterTest.java
+++ b/src/test/java/org/folio/sidecar/integration/keycloak/filter/KeycloakTenantFilterTest.java
@@ -192,6 +192,53 @@ class KeycloakTenantFilterTest extends AbstractFilterTest {
   }
 
   @Test
+  void shouldSkip_negative_wildcardPermission() {
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {});
+    var actual = keycloakTenantFilter.shouldSkip(routingContext);
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void filter_positive_wildcardTenantMatches() {
+    var accessToken = mock(JsonWebToken.class);
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.get(RoutingUtils.SELF_REQUEST_KEY)).thenReturn(false);
+      when(rc.get(PARSED_TOKEN)).thenReturn(accessToken);
+      when(rc.get(SYSTEM_TOKEN)).thenReturn(null);
+      when(accessToken.getIssuer()).thenReturn(keycloakIssuer(TENANT_NAME));
+      when(rc.request().getHeader(TENANT)).thenReturn(TENANT_NAME);
+    });
+
+    when(sidecarProperties.isCrossTenantEnabled()).thenReturn(false);
+
+    var result = keycloakTenantFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isTrue();
+    assertThat(result.result()).isEqualTo(routingContext);
+  }
+
+  @Test
+  void filter_negative_wildcardTenantMismatch() {
+    var accessToken = mock(JsonWebToken.class);
+    var routingContext = routingContext(scRoutingEntry("not-system", "*"), rc -> {
+      when(rc.get(RoutingUtils.SELF_REQUEST_KEY)).thenReturn(false);
+      when(rc.get(PARSED_TOKEN)).thenReturn(accessToken);
+      when(rc.get(SYSTEM_TOKEN)).thenReturn(null);
+      when(accessToken.getIssuer()).thenReturn(keycloakIssuer("test-tenant-a"));
+      when(rc.request().getHeader(TENANT)).thenReturn("test-tenant-b");
+    });
+
+    when(sidecarProperties.isCrossTenantEnabled()).thenReturn(false);
+
+    var result = keycloakTenantFilter.applyFilter(routingContext);
+
+    assertThat(result.succeeded()).isFalse();
+    assertThat(result.cause())
+      .isInstanceOf(UnauthorizedException.class)
+      .hasMessage("X-Okapi-Tenant header is not the same as resolved tenant");
+  }
+
+  @Test
   void shouldSkip_positive_selfRequest() {
     var routingContext = routingContext(scRoutingEntry("not-system", "foo.item.get"),
       rc -> when(rc.get(RoutingUtils.SELF_REQUEST_KEY)).thenReturn(true));

--- a/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
+++ b/src/test/java/org/folio/sidecar/utils/RoutingUtilsTest.java
@@ -9,8 +9,11 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.web.RoutingContext;
+import java.util.List;
 import java.util.Map;
+import org.folio.sidecar.integration.am.model.ModuleBootstrapEndpoint;
 import org.folio.sidecar.integration.okapi.OkapiHeaders;
+import org.folio.sidecar.model.ScRoutingEntry;
 import org.folio.support.types.UnitTest;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +59,75 @@ class RoutingUtilsTest {
     var routingContext = routingContext("111111/users", Map.of("X-Okapi-Token", "null"));
     assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", false)).isTrue();
     assertThat(RoutingUtils.hasHeaderWithValue(routingContext, "X-Okapi-Token", true)).isFalse();
+  }
+
+  @Test
+  void isTrulyPublic_positive_emptyPermissions() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of()))).isTrue();
+  }
+
+  @Test
+  void isTrulyPublic_positive_nullPermissions() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(null))).isTrue();
+  }
+
+  @Test
+  void isTrulyPublic_negative_namedPermission() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void isTrulyPublic_negative_wildcard() {
+    assertThat(RoutingUtils.isTrulyPublic(rcWithPermissions(List.of("*")))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_positive_singletonWildcard() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("*")))).isTrue();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_mixedList() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("*", "foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_emptyList() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of()))).isFalse();
+  }
+
+  @Test
+  void isWildcardPermissionRequired_negative_namedPermission() {
+    assertThat(RoutingUtils.isWildcardPermissionRequired(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void requiresNoNamedPermission_positive_trulyPublic() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of()))).isTrue();
+  }
+
+  @Test
+  void requiresNoNamedPermission_positive_wildcard() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("*")))).isTrue();
+  }
+
+  @Test
+  void requiresNoNamedPermission_negative_namedPermission() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("foo.item.get")))).isFalse();
+  }
+
+  @Test
+  void requiresNoNamedPermission_negative_mixedList() {
+    assertThat(RoutingUtils.requiresNoNamedPermission(rcWithPermissions(List.of("*", "foo.item.get")))).isFalse();
+  }
+
+  private static RoutingContext rcWithPermissions(List<String> permissionsRequired) {
+    var endpoint = new ModuleBootstrapEndpoint("/foo/items", "GET");
+    endpoint.setPermissionsRequired(permissionsRequired);
+    var entry = ScRoutingEntry.of("mod-foo-1.0", "http://mod-foo", "mod-foo-api-1.0", endpoint);
+    var rc = mock(RoutingContext.class);
+    when(rc.get(RoutingUtils.SC_ROUTING_ENTRY_KEY)).thenReturn(entry);
+    return rc;
   }
 
   private static RoutingContext routingContext(String requestId, Map<String, String> headers) {


### PR DESCRIPTION
## Summary

Treats `permissionsRequired: ["*"]` as "valid token + tenant required, but no named permission", while keeping `permissionsRequired: []` (or null) as truly public. Only the exact singleton `["*"]` activates the wildcard convention; any other list (including `["*", "x"]`) falls through to the existing named-permission RPT path. Implements Jira [MODSIDECAR-198](https://folio-org.atlassian.net/browse/MODSIDECAR-198).

## Changes

- `RoutingUtils`: add `isTrulyPublic`, `isWildcardPermissionRequired`, `requiresNoNamedPermission`; remove the dead `hasNoPermissionsRequired` alias.
- `KeycloakAuthorizationFilter`: skip Keycloak RPT (UMA) evaluation for wildcard-authenticated endpoints — the one behavioral change.
- `KeycloakTenantFilter` / `KeycloakJwtFilter`: switch to `isTrulyPublic` (behavior-preserving rename) so `["*"]` still requires a parsed JWT and a validated tenant.
- Tests: new `RoutingUtils` predicate tests + filter tests covering all 6 acceptance criteria (public / wildcard / named / mixed, token present-absent, tenant match-mismatch).
- Adds SDLC planning artifacts and `.ai-run/guides/` foundation (commit `e0b12c1`). That commit is self-contained and can be dropped if a code-only PR is preferred.

## Impact

**Security-sensitive — modifies ingress authorization.** Wildcard endpoints remain authenticated (valid JWT) and tenant-bound; only the named-permission RPT check is skipped. No change for `[]`/null (public) or named-permission endpoints. Backward compatible.

| `permissionsRequired` | Token | Tenant | Named-perm RPT |
|---|---|---|---|
| `[]` / null (before & after) | not required | not checked | skipped |
| `["*"]` — **before** | required | checked | **run (always failed — no named perm)** |
| `["*"]` — **after** | required | checked | **skipped** |
| `["perm.x"]` (before & after) | required | checked | run |

## Checklist

- [x] Self-reviewed (multi-lens automated code review approved at high confidence; independent security review found no newly-introduced vulnerabilities)
- [x] Automated tests pass (541 unit + 73 integration; checkstyle clean) — manual testing N/A (internal authorization logic, no UI surface)
- [x] No documentation change needed (no env-var, endpoint, or public-API change)
- [x] No breaking changes (`[]`/null and named-permission endpoints behave exactly as before)
