### PR TITLE
MODSIDECAR-204: enable other artifacts in Docker workflow configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,3 +20,4 @@ jobs:
       allow-snapshots-release: false
       do-sonar-scan: true
       do-docker: true
+      docker-enable-other-artifacts: true


### PR DESCRIPTION
### **Purpose**
Enable Docker workflow support for additional published artifacts in this module repository. This updates the shared Maven Central workflow invocation so Docker builds can include those artifacts when needed. Related issue: https://folio-org.atlassian.net/browse/MODSIDECAR-204.

### **Approach**
- Enable the `docker-enable-other-artifacts` input in `.github/workflows/maven.yml`.
- Keep the existing shared workflow configuration unchanged apart from this Docker-related flag.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **New Properties / Environment Variables**— Updated README.md if new configs were added.
- [ ] **Breaking Changes (if any)** — Identified and handled if changes affect integrations or contracts with other services.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.